### PR TITLE
Directly specify password in the 'password-update' command

### DIFF
--- a/command/REPLCommand.java
+++ b/command/REPLCommand.java
@@ -379,7 +379,7 @@ public interface REPLCommand {
         public static class PasswordUpdate extends REPLCommand.User {
 
             public static String token = "password-update";
-            private static String helpCommand = User.token + " " + token;
+            private static String helpCommand = User.token + " " + token + " [old-password new-password]";
             private static String description = "Update the password of the current user";
 
             private final String passwordOld;
@@ -751,10 +751,17 @@ public interface REPLCommand {
             if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
             String password = Utils.readPassword(passwordReader, "Password: ");
             command = new User.Create(name, password);
-        } else if (tokens.length == 2 && tokens[0].equals(User.token) && tokens[1].equals(User.PasswordUpdate.token)) {
-            if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
-            String passwordOld = Utils.readPassword(passwordReader, "Old password: ");
-            String passwordNew = Utils.readPassword(passwordReader, "New password: ");
+        } else if ((tokens.length == 2 || tokens.length == 4) && tokens[0].equals(User.token) && tokens[1].equals(User.PasswordUpdate.token)) {
+            String passwordOld;
+            String passwordNew;
+            if (tokens.length == 2) {
+                if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
+                passwordOld = Utils.readPassword(passwordReader, "Old password: ");
+                passwordNew = Utils.readPassword(passwordReader, "New password: ");
+            } else {
+                passwordOld = tokens[2];
+                passwordNew = tokens[3];
+            }
             command = new User.PasswordUpdate(passwordOld, passwordNew);
         } else if (tokens.length == 3 && tokens[0].equals(User.token) && tokens[1].equals(User.PasswordSet.token)) {
             String name = tokens[2];


### PR DESCRIPTION
## Usage and product changes

It is now possible to invoke `password-update` command and specify the password together, instead of having to supply them in the following prompt. This new variant makes it possible to call it non-interactively.

## Implementation
1. Add a new variant to the password-update command: `user password-update <old-password> <new-password>`
2. Update the help text accordingly