### PR TITLE
Refactor console for 3.0

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -35,12 +35,13 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
-    test-assembly:
-      image: vaticle-ubuntu-22.04
-      type: foreground
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/assembly:test-assembly-native --test_output=streamed
+#    TODO: Cannot be run without a running 3.0 server
+#    test-assembly:
+#      image: vaticle-ubuntu-22.04
+#      type: foreground
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/assembly:test-assembly-native --test_output=streamed
     deploy-runner-maven-snapshot:
       filter:
         owner: vaticle

--- a/BUILD
+++ b/BUILD
@@ -33,6 +33,11 @@ java_library(
         "@vaticle_typedb_driver//java:driver-java",
         "@vaticle_typedb_driver//java/api",
         "@vaticle_typedb_driver//java/common",
+        "@vaticle_typeql//java:typeql-lang",
+        "@vaticle_typeql//java/common:common",
+        "@vaticle_typeql//java/query",
+        "@vaticle_typeql//java/pattern",
+        "@vaticle_typeql//common/java:common",
 
         # External dependencies
         "@maven//:com_google_code_findbugs_jsr305",
@@ -115,66 +120,66 @@ assemble_zip(
     target_compatible_with = constraint_win_x86_64
 )
 
-#deploy_artifact(
-#    name = "deploy-linux-x86_64-targz",
-#    target = ":assemble-linux-x86_64-targz",
-#    artifact_group = "typedb-console-linux-x86_64",
-#    artifact_name = "typedb-console-linux-x86_64-{version}.tar.gz",
-#    snapshot = deployment['artifact']['snapshot']['upload'],
-#    release = deployment['artifact']['release']['upload'],
-#    visibility = ["//visibility:public"],
-#)
-#
-#deploy_artifact(
-#    name = "deploy-linux-arm64-targz",
-#    target = ":assemble-linux-arm64-targz",
-#    artifact_group = "typedb-console-linux-arm64",
-#    artifact_name = "typedb-console-linux-arm64-{version}.tar.gz",
-#    snapshot = deployment['artifact']['snapshot']['upload'],
-#    release = deployment['artifact']['release']['upload'],
-#    visibility = ["//visibility:public"],
-#)
-#
-#deploy_artifact(
-#    name = "deploy-mac-x86_64-zip",
-#    target = ":assemble-mac-x86_64-zip",
-#    artifact_group = "typedb-console-mac-x86_64",
-#    artifact_name = "typedb-console-mac-x86_64-{version}.zip",
-#    snapshot = deployment['artifact']['snapshot']['upload'],
-#    release = deployment['artifact']['release']['upload'],
-#    visibility = ["//visibility:public"],
-#)
-#
-#deploy_artifact(
-#    name = "deploy-mac-arm64-zip",
-#    target = ":assemble-mac-arm64-zip",
-#    artifact_group = "typedb-console-mac-arm64",
-#    artifact_name = "typedb-console-mac-arm64-{version}.zip",
-#    snapshot = deployment['artifact']['snapshot']['upload'],
-#    release = deployment['artifact']['release']['upload'],
-#    visibility = ["//visibility:public"],
-#)
-#
-#deploy_artifact(
-#    name = "deploy-windows-x86_64-zip",
-#    target = ":assemble-windows-x86_64-zip",
-#    artifact_group = "typedb-console-windows-x86_64",
-#    artifact_name = "typedb-console-windows-x86_64-{version}.zip",
-#    snapshot = deployment['artifact']['snapshot']['upload'],
-#    release = deployment['artifact']['release']['upload'],
-#    visibility = ["//visibility:public"],
-#)
+deploy_artifact(
+    name = "deploy-linux-x86_64-targz",
+    target = ":assemble-linux-x86_64-targz",
+    artifact_group = "typedb-console-linux-x86_64",
+    artifact_name = "typedb-console-linux-x86_64-{version}.tar.gz",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+)
 
-#release_validate_deps(
-#    name = "release-validate-deps",
-#    refs = "@vaticle_typedb_console_workspace_refs//:refs.json",
-#    tagged_deps = [
-#        "@vaticle_typedb_driver",
-#        "@vaticle_typeql",
-#    ],
-#    tags = ["manual"], # in order for bazel test //... to not fail
-#    version_file = "VERSION",
-#)
+deploy_artifact(
+    name = "deploy-linux-arm64-targz",
+    target = ":assemble-linux-arm64-targz",
+    artifact_group = "typedb-console-linux-arm64",
+    artifact_name = "typedb-console-linux-arm64-{version}.tar.gz",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+)
+
+deploy_artifact(
+    name = "deploy-mac-x86_64-zip",
+    target = ":assemble-mac-x86_64-zip",
+    artifact_group = "typedb-console-mac-x86_64",
+    artifact_name = "typedb-console-mac-x86_64-{version}.zip",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+)
+
+deploy_artifact(
+    name = "deploy-mac-arm64-zip",
+    target = ":assemble-mac-arm64-zip",
+    artifact_group = "typedb-console-mac-arm64",
+    artifact_name = "typedb-console-mac-arm64-{version}.zip",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+)
+
+deploy_artifact(
+    name = "deploy-windows-x86_64-zip",
+    target = ":assemble-windows-x86_64-zip",
+    artifact_group = "typedb-console-windows-x86_64",
+    artifact_name = "typedb-console-windows-x86_64-{version}.zip",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+)
+
+release_validate_deps(
+    name = "release-validate-deps",
+    refs = "@vaticle_typedb_console_workspace_refs//:refs.json",
+    tagged_deps = [
+        "@vaticle_typedb_driver",
+        "@vaticle_typeql",
+    ],
+    tags = ["manual"], # in order for bazel test //... to not fail
+    version_file = "VERSION",
+)
 
 checkstyle_test(
     name = "checkstyle",

--- a/BUILD
+++ b/BUILD
@@ -33,11 +33,6 @@ java_library(
         "@vaticle_typedb_driver//java:driver-java",
         "@vaticle_typedb_driver//java/api",
         "@vaticle_typedb_driver//java/common",
-        "@vaticle_typeql//java:typeql-lang",
-        "@vaticle_typeql//java/common:common",
-        "@vaticle_typeql//java/query",
-        "@vaticle_typeql//java/pattern",
-        "@vaticle_typeql//common/java:common",
 
         # External dependencies
         "@maven//:com_google_code_findbugs_jsr305",
@@ -120,66 +115,66 @@ assemble_zip(
     target_compatible_with = constraint_win_x86_64
 )
 
-deploy_artifact(
-    name = "deploy-linux-x86_64-targz",
-    target = ":assemble-linux-x86_64-targz",
-    artifact_group = "typedb-console-linux-x86_64",
-    artifact_name = "typedb-console-linux-x86_64-{version}.tar.gz",
-    snapshot = deployment['artifact']['snapshot']['upload'],
-    release = deployment['artifact']['release']['upload'],
-    visibility = ["//visibility:public"],
-)
+#deploy_artifact(
+#    name = "deploy-linux-x86_64-targz",
+#    target = ":assemble-linux-x86_64-targz",
+#    artifact_group = "typedb-console-linux-x86_64",
+#    artifact_name = "typedb-console-linux-x86_64-{version}.tar.gz",
+#    snapshot = deployment['artifact']['snapshot']['upload'],
+#    release = deployment['artifact']['release']['upload'],
+#    visibility = ["//visibility:public"],
+#)
+#
+#deploy_artifact(
+#    name = "deploy-linux-arm64-targz",
+#    target = ":assemble-linux-arm64-targz",
+#    artifact_group = "typedb-console-linux-arm64",
+#    artifact_name = "typedb-console-linux-arm64-{version}.tar.gz",
+#    snapshot = deployment['artifact']['snapshot']['upload'],
+#    release = deployment['artifact']['release']['upload'],
+#    visibility = ["//visibility:public"],
+#)
+#
+#deploy_artifact(
+#    name = "deploy-mac-x86_64-zip",
+#    target = ":assemble-mac-x86_64-zip",
+#    artifact_group = "typedb-console-mac-x86_64",
+#    artifact_name = "typedb-console-mac-x86_64-{version}.zip",
+#    snapshot = deployment['artifact']['snapshot']['upload'],
+#    release = deployment['artifact']['release']['upload'],
+#    visibility = ["//visibility:public"],
+#)
+#
+#deploy_artifact(
+#    name = "deploy-mac-arm64-zip",
+#    target = ":assemble-mac-arm64-zip",
+#    artifact_group = "typedb-console-mac-arm64",
+#    artifact_name = "typedb-console-mac-arm64-{version}.zip",
+#    snapshot = deployment['artifact']['snapshot']['upload'],
+#    release = deployment['artifact']['release']['upload'],
+#    visibility = ["//visibility:public"],
+#)
+#
+#deploy_artifact(
+#    name = "deploy-windows-x86_64-zip",
+#    target = ":assemble-windows-x86_64-zip",
+#    artifact_group = "typedb-console-windows-x86_64",
+#    artifact_name = "typedb-console-windows-x86_64-{version}.zip",
+#    snapshot = deployment['artifact']['snapshot']['upload'],
+#    release = deployment['artifact']['release']['upload'],
+#    visibility = ["//visibility:public"],
+#)
 
-deploy_artifact(
-    name = "deploy-linux-arm64-targz",
-    target = ":assemble-linux-arm64-targz",
-    artifact_group = "typedb-console-linux-arm64",
-    artifact_name = "typedb-console-linux-arm64-{version}.tar.gz",
-    snapshot = deployment['artifact']['snapshot']['upload'],
-    release = deployment['artifact']['release']['upload'],
-    visibility = ["//visibility:public"],
-)
-
-deploy_artifact(
-    name = "deploy-mac-x86_64-zip",
-    target = ":assemble-mac-x86_64-zip",
-    artifact_group = "typedb-console-mac-x86_64",
-    artifact_name = "typedb-console-mac-x86_64-{version}.zip",
-    snapshot = deployment['artifact']['snapshot']['upload'],
-    release = deployment['artifact']['release']['upload'],
-    visibility = ["//visibility:public"],
-)
-
-deploy_artifact(
-    name = "deploy-mac-arm64-zip",
-    target = ":assemble-mac-arm64-zip",
-    artifact_group = "typedb-console-mac-arm64",
-    artifact_name = "typedb-console-mac-arm64-{version}.zip",
-    snapshot = deployment['artifact']['snapshot']['upload'],
-    release = deployment['artifact']['release']['upload'],
-    visibility = ["//visibility:public"],
-)
-
-deploy_artifact(
-    name = "deploy-windows-x86_64-zip",
-    target = ":assemble-windows-x86_64-zip",
-    artifact_group = "typedb-console-windows-x86_64",
-    artifact_name = "typedb-console-windows-x86_64-{version}.zip",
-    snapshot = deployment['artifact']['snapshot']['upload'],
-    release = deployment['artifact']['release']['upload'],
-    visibility = ["//visibility:public"],
-)
-
-release_validate_deps(
-    name = "release-validate-deps",
-    refs = "@vaticle_typedb_console_workspace_refs//:refs.json",
-    tagged_deps = [
-        "@vaticle_typedb_driver",
-        "@vaticle_typeql",
-    ],
-    tags = ["manual"], # in order for bazel test //... to not fail
-    version_file = "VERSION",
-)
+#release_validate_deps(
+#    name = "release-validate-deps",
+#    refs = "@vaticle_typedb_console_workspace_refs//:refs.json",
+#    tagged_deps = [
+#        "@vaticle_typedb_driver",
+#        "@vaticle_typeql",
+#    ],
+#    tags = ["manual"], # in order for bazel test //... to not fail
+#    version_file = "VERSION",
+#)
 
 checkstyle_test(
     name = "checkstyle",

--- a/README.md
+++ b/README.md
@@ -20,12 +20,7 @@ cd <your_typedb_console_dir>/
 You can provide several command arguments when running console in the terminal.
 
 - `--core=<address>` : TypeDB server address to which the console will connect to.
-- `--cloud=<address>` : TypeDB Cloud server address to which the console will connect to.
-- `--username=<username>` : TypeDB Cloud username to connect with.
-- `--password` : Interactively enter password to connect to TypeDB Cloud with.
 - `--script=<script>` : Run commands in the script file in non-interactive mode.
-- `--tls-enabled`: Enable TLS for connecting to TypeDB Cloud.
-- `--tls-root-ca`: Path to root CA certificate for TLS encryption.
 - `--command=<command1> --command=<command2> ...` : Run commands in non-interactive mode.
 - `-V, --version` : Print version information and exit.
 - `-h, --help` : Show help message.
@@ -53,16 +48,10 @@ Console also offers command completion, accessible with a `tab` keypress.
   > database delete my-typedb-database
   Database 'my-typedb-database' deleted
   ```
-- `database schema <db>` : Print the schema of a database with name `<db>` on the server. For example:
+- `transaction <db> read|write|schema` : Start a `read`, `write`, or `schema` transaction to database `<db>`. For example:
   ```
-  > database schema my-typedb-database
-  define
-  person sub entity;
-  ```
-- `transaction <db> schema|data read|write` : Start a transaction to database `<db>` with session type `schema` or `data`, and transaction type `write` or `read`. For example:
-  ```
-  > transaction my-typedb-database schema write
-  my-typedb-database::schema::write>
+  > transaction my-typedb-database schema
+  my-typedb-database::schema>
   ```
   This will then take you to the transaction-level interface, i.e. the second-level REPL.
 - `help` : Print help menu
@@ -73,30 +62,30 @@ Console also offers command completion, accessible with a `tab` keypress.
 
 - `<query>` : Once you're in the transaction REPL, the terminal immediately accepts a multi-line TypeQL query, and will execute it when you hit enter twice. For example:
   ```
-  my-typedb-database::schema::write> define
-                                     name sub attribute, value string;
-                                     person sub entity, owns name;
+  my-typedb-database::schema> define
+                              attribute name, value string;
+                              entity person, owns name;
 
-  Concepts have been defined
+  Success
   ```
 - `source <file>` : Run TypeQL queries in a file, which you can refer to using relative or absolute path. For example:
   ```
-  my-typedb-database::schema::write> source ./schema.gql
+  my-typedb-database::schema> source ./schema.tql
   Concepts have been defined
   ```
 - `commit` : Commit the transaction changes and close transaction. For example:
   ```
-  my-typedb-database::schema::write> commit
+  my-typedb-database::schema> commit
   Transaction changes committed
   ```
 - `rollback` : Will remove any uncommitted changes you've made in the transaction, while leaving transaction open. For example:
   ```
-  my-typedb-database::schema::write> rollback
-  Rolled back to the beginning of the transaction
+  my-typedb-database::schema> rollback
+  Transaction changes have rolled back, i.e. erased, and not committed
   ```
 - `close` : Close the transaction without committing changes, and takes you back to the database-level interface, i.e. first-level REPL. For example:
   ```
-  my-typedb-database::schema::write> close
+  my-typedb-database::schema> close
   Transaction closed without committing changes
   ```
 - `help` : Print this help menu
@@ -111,13 +100,13 @@ For example given the following command script file:
 
 ```
 database create test
-transaction test schema write
-    define person sub entity;
+transaction test schema 
+    define entity person;
     commit
-transaction test data write
+transaction test write
     insert $x isa person;
     commit
-transaction test data read
+transaction test read
     match $x isa person;
     close
 database delete test
@@ -129,9 +118,9 @@ You will see the following output:
 > ./typedb console --script=script                                                                                                                                                                                                                    73.830s
 + database create test
 Database 'test' created
-+ transaction test schema write
-++ define person sub entity;
-Concepts have been defined
++ transaction test schema
+++ define entity person;
+Success
 ++ commit
 Transaction changes committed
 + transaction test data write

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ database delete test
 ```
 
 You will see the following output:
-
+# TODO: Update the output!
 ```
 > ./typedb console --script=script                                                                                                                                                                                                                    73.830s
 + database create test

--- a/RunQueriesResult.java
+++ b/RunQueriesResult.java
@@ -8,22 +8,16 @@ package com.vaticle.typedb.console;
 
 public class RunQueriesResult {
     private final boolean success;
-    private final boolean hasChanges;
 
-    public RunQueriesResult(boolean success, boolean hasChanges) {
+    public RunQueriesResult(boolean success) {
         this.success = success;
-        this.hasChanges = hasChanges;
     }
 
     public static RunQueriesResult error() {
-        return new RunQueriesResult(false, false);
+        return new RunQueriesResult(false);
     }
 
     public boolean success() {
         return success;
-    }
-
-    public boolean hasChanges() {
-        return hasChanges;
     }
 }

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -671,12 +671,12 @@ public class TypeDBConsole {
 
     private void runRollback(TypeDBTransaction tx) {
         tx.rollback();
-        printer.info("Transaction changes have rolled back, i.e. erased, and not committed.");
+        printer.info("Transaction changes have rolled back, i.e. erased, and not committed");
     }
 
     private void runClose(TypeDBTransaction tx) {
         tx.close();
-        if (tx.getType().isWrite()) printer.info("Transaction closed without committing changes");
+        if (tx.getType().isWrite() || tx.getType().isSchema()) printer.info("Transaction closed without committing changes");
         else printer.info("Transaction closed");
     }
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -160,7 +160,7 @@ vaticle_typedb_artifact()
 # Load maven
 load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_artifacts = "artifacts")
 load("@vaticle_typedb_driver//dependencies/maven:artifacts.bzl", vaticle_typedb_driver_artifacts = "artifacts")
-load("@vaticle_typedb_driver//dependencies/vaticle:artifacts.bzl", vaticle_typedb_vaticle_maven_artifacts = "maven_artifacts")
+#load("@vaticle_typedb_driver//dependencies/vaticle:artifacts.bzl", vaticle_typedb_vaticle_maven_artifacts = "maven_artifacts")
 load("//dependencies/maven:artifacts.bzl", vaticle_typedb_console_artifacts = "artifacts")
 
 ###############
@@ -175,7 +175,7 @@ maven(
     vaticle_dependencies_tool_maven_artifacts +
     io_grpc_artifacts,
     generate_compat_repositories = True,
-    internal_artifacts = vaticle_typedb_vaticle_maven_artifacts,
+#    internal_artifacts = vaticle_typedb_vaticle_maven_artifacts,
 )
 
 load("@maven//:compat.bzl", "compat_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -149,7 +149,8 @@ google_common_workspace_rules()
 load("//dependencies/vaticle:repositories.bzl", "vaticle_typedb_driver")
 vaticle_typedb_driver()
 
-load("@vaticle_typedb_driver//dependencies/vaticle:repositories.bzl", "vaticle_typedb_protocol")
+load("@vaticle_typedb_driver//dependencies/vaticle:repositories.bzl", "vaticle_typedb_protocol", "vaticle_typeql")
+vaticle_typeql()
 vaticle_typedb_protocol()
 
 # Load artifacts
@@ -157,6 +158,7 @@ load("@vaticle_typedb_driver//dependencies/vaticle:artifacts.bzl", "vaticle_type
 vaticle_typedb_artifact()
 
 # Load maven
+load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_artifacts = "artifacts")
 load("@vaticle_typedb_driver//dependencies/maven:artifacts.bzl", vaticle_typedb_driver_artifacts = "artifacts")
 load("@vaticle_typedb_driver//dependencies/vaticle:artifacts.bzl", vaticle_typedb_vaticle_maven_artifacts = "maven_artifacts")
 load("//dependencies/maven:artifacts.bzl", vaticle_typedb_console_artifacts = "artifacts")
@@ -167,6 +169,7 @@ load("//dependencies/maven:artifacts.bzl", vaticle_typedb_console_artifacts = "a
 
 load("@vaticle_dependencies//library/maven:rules.bzl", "maven")
 maven(
+    vaticle_typeql_artifacts +
     vaticle_typedb_driver_artifacts +
     vaticle_typedb_console_artifacts +
     vaticle_dependencies_tool_maven_artifacts +

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -149,8 +149,7 @@ google_common_workspace_rules()
 load("//dependencies/vaticle:repositories.bzl", "vaticle_typedb_driver")
 vaticle_typedb_driver()
 
-load("@vaticle_typedb_driver//dependencies/vaticle:repositories.bzl", "vaticle_typedb_protocol", "vaticle_typeql")
-vaticle_typeql()
+load("@vaticle_typedb_driver//dependencies/vaticle:repositories.bzl", "vaticle_typedb_protocol")
 vaticle_typedb_protocol()
 
 # Load artifacts
@@ -158,7 +157,6 @@ load("@vaticle_typedb_driver//dependencies/vaticle:artifacts.bzl", "vaticle_type
 vaticle_typedb_artifact()
 
 # Load maven
-load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_artifacts = "artifacts")
 load("@vaticle_typedb_driver//dependencies/maven:artifacts.bzl", vaticle_typedb_driver_artifacts = "artifacts")
 load("@vaticle_typedb_driver//dependencies/vaticle:artifacts.bzl", vaticle_typedb_vaticle_maven_artifacts = "maven_artifacts")
 load("//dependencies/maven:artifacts.bzl", vaticle_typedb_console_artifacts = "artifacts")
@@ -169,7 +167,6 @@ load("//dependencies/maven:artifacts.bzl", vaticle_typedb_console_artifacts = "a
 
 load("@vaticle_dependencies//library/maven:rules.bzl", "maven")
 maven(
-    vaticle_typeql_artifacts +
     vaticle_typedb_driver_artifacts +
     vaticle_typedb_console_artifacts +
     vaticle_dependencies_tool_maven_artifacts +

--- a/command/REPLCommand.java
+++ b/command/REPLCommand.java
@@ -6,24 +6,20 @@
 
 package com.vaticle.typedb.console.command;
 
-import com.vaticle.typedb.driver.api.TypeDBDriver;
-import com.vaticle.typedb.driver.api.TypeDBOptions;
-import com.vaticle.typedb.driver.api.TypeDBTransaction;
 import com.vaticle.typedb.common.collection.Pair;
 import com.vaticle.typedb.console.common.Printer;
 import com.vaticle.typedb.console.common.Utils;
 import com.vaticle.typedb.console.common.exception.TypeDBConsoleException;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
 import org.jline.reader.LineReader;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.BiFunction;
 
-import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.pair;
-import static com.vaticle.typedb.console.common.exception.ErrorMessage.Console.UNABLE_TO_READ_PASSWORD_INTERACTIVELY;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 
 public interface REPLCommand {
@@ -52,45 +48,45 @@ public interface REPLCommand {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
-    default boolean isUserList() {
-        return false;
-    }
-
-    default User.List asUserList() {
-        throw new TypeDBConsoleException(ILLEGAL_CAST);
-    }
-
-    default boolean isUserCreate() {
-        return false;
-    }
-
-    default User.Create asUserCreate() {
-        throw new TypeDBConsoleException(ILLEGAL_CAST);
-    }
-
-    default boolean isUserPasswordUpdate() {
-        return false;
-    }
-
-    default User.PasswordUpdate asUserPasswordUpdate() {
-        throw new TypeDBConsoleException(ILLEGAL_CAST);
-    }
-
-    default boolean isUserPasswordSet() {
-        return false;
-    }
-
-    default User.PasswordSet asUserPasswordSet() {
-        throw new TypeDBConsoleException(ILLEGAL_CAST);
-    }
-
-    default boolean isUserDelete() {
-        return false;
-    }
-
-    default User.Delete asUserDelete() {
-        throw new TypeDBConsoleException(ILLEGAL_CAST);
-    }
+//    default boolean isUserList() {
+//        return false;
+//    }
+//
+//    default User.List asUserList() {
+//        throw new TypeDBConsoleException(ILLEGAL_CAST);
+//    }
+//
+//    default boolean isUserCreate() {
+//        return false;
+//    }
+//
+//    default User.Create asUserCreate() {
+//        throw new TypeDBConsoleException(ILLEGAL_CAST);
+//    }
+//
+//    default boolean isUserPasswordUpdate() {
+//        return false;
+//    }
+//
+//    default User.PasswordUpdate asUserPasswordUpdate() {
+//        throw new TypeDBConsoleException(ILLEGAL_CAST);
+//    }
+//
+//    default boolean isUserPasswordSet() {
+//        return false;
+//    }
+//
+//    default User.PasswordSet asUserPasswordSet() {
+//        throw new TypeDBConsoleException(ILLEGAL_CAST);
+//    }
+//
+//    default boolean isUserDelete() {
+//        return false;
+//    }
+//
+//    default User.Delete asUserDelete() {
+//        throw new TypeDBConsoleException(ILLEGAL_CAST);
+//    }
 
     default boolean isDatabaseList() {
         return false;
@@ -124,13 +120,13 @@ public interface REPLCommand {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
-    default boolean isDatabaseReplicas() {
-        return false;
-    }
-
-    default Database.Replicas asDatabaseReplicas() {
-        throw new TypeDBConsoleException(ILLEGAL_CAST);
-    }
+//    default boolean isDatabaseReplicas() {
+//        return false;
+//    }
+//
+//    default Database.Replicas asDatabaseReplicas() {
+//        throw new TypeDBConsoleException(ILLEGAL_CAST);
+//    }
 
     default boolean isTransaction() {
         return false;
@@ -293,197 +289,198 @@ public interface REPLCommand {
             }
         }
 
-        public static class Replicas extends REPLCommand.Database {
-
-            public static String token = "replicas";
-            private static String helpCommand = Database.token + " " + token + " " + "<db>";
-            private static String description = "List replicas of a database with name <db>";
-
-            private final String database;
-
-            public Replicas(String database) {
-                this.database = database;
-            }
-
-            public String database() {
-                return database;
-            }
-
-            @Override
-            public boolean isDatabaseReplicas() {
-                return true;
-            }
-
-            @Override
-            public Database.Replicas asDatabaseReplicas() {
-                return this;
-            }
-        }
+//        public static class Replicas extends REPLCommand.Database {
+//
+//            public static String token = "replicas";
+//            private static String helpCommand = Database.token + " " + token + " " + "<db>";
+//            private static String description = "List replicas of a database with name <db>";
+//
+//            private final String database;
+//
+//            public Replicas(String database) {
+//                this.database = database;
+//            }
+//
+//            public String database() {
+//                return database;
+//            }
+//
+//            @Override
+//            public boolean isDatabaseReplicas() {
+//                return true;
+//            }
+//
+//            @Override
+//            public Database.Replicas asDatabaseReplicas() {
+//                return this;
+//            }
+//        }
     }
 
-    abstract class User implements REPLCommand {
-
-        public static String token = "user";
-
-        public static class List extends REPLCommand.User {
-
-            public static String token = "list";
-            private static String helpCommand = User.token + " " + token;
-            private static String description = "List the users on the server";
-
-            @Override
-            public boolean isUserList() {
-                return true;
-            }
-
-            @Override
-            public User.List asUserList() {
-                return this;
-            }
-        }
-
-        public static class Create extends REPLCommand.User {
-
-            public static String token = "create";
-            private static String helpCommand = User.token + " " + token + " " + "<username>";
-            private static String description = "Create a user with name <username> and a supplied password on the server";
-
-            private final String user;
-            private final String password;
-
-            public Create(String user, String password) {
-                this.user = user;
-                this.password = password;
-            }
-
-            public String user() {
-                return user;
-            }
-
-            public String password() {
-                return password;
-            }
-
-            @Override
-            public boolean isUserCreate() {
-                return true;
-            }
-
-            @Override
-            public User.Create asUserCreate() {
-                return this;
-            }
-        }
-
-        public static class PasswordUpdate extends REPLCommand.User {
-
-            public static String token = "password-update";
-            private static String helpCommand = User.token + " " + token + " [old-password new-password]";
-            private static String description = "Update the password of the current user";
-
-            private final String passwordOld;
-            private final String passwordNew;
-
-            public PasswordUpdate(String passwordOld, String passwordNew) {
-                this.passwordOld = passwordOld;
-                this.passwordNew = passwordNew;
-            }
-
-            public String passwordOld() {
-                return passwordOld;
-            }
-
-            public String passwordNew() {
-                return passwordNew;
-            }
-
-            @Override
-            public boolean isUserPasswordUpdate() {
-                return true;
-            }
-
-            @Override
-            public PasswordUpdate asUserPasswordUpdate() {
-                return this;
-            }
-        }
-
-        public static class PasswordSet extends REPLCommand.User {
-
-            public static String token = "password-set";
-            private static String helpCommand = User.token + " " + token + " " + "<username>";
-            private static String description = "Set the password of user with name <username>";
-
-            private final String user;
-
-            private final String password;
-
-            public PasswordSet(String user, String password) {
-                this.user = user;
-                this.password = password;
-            }
-
-            public String user() {
-                return user;
-            }
-
-            public String password() {
-                return password;
-            }
-
-            @Override
-            public boolean isUserPasswordSet() {
-                return true;
-            }
-
-            @Override
-            public PasswordSet asUserPasswordSet() {
-                return this;
-            }
-        }
-
-        public static class Delete extends REPLCommand.User {
-
-            public static String token = "delete";
-            private static String helpCommand = User.token + " " + token + " " + "<username>";
-            private static String description = "Delete a user with name <username> on the server";
-
-            private final String user;
-
-            public Delete(String user) {
-                this.user = user;
-            }
-
-            public String user() {
-                return user;
-            }
-
-            @Override
-            public boolean isUserDelete() {
-                return true;
-            }
-
-            @Override
-            public User.Delete asUserDelete() {
-                return this;
-            }
-        }
-    }
+//    abstract class User implements REPLCommand {
+//
+//        public static String token = "user";
+//
+//        public static class List extends REPLCommand.User {
+//
+//            public static String token = "list";
+//            private static String helpCommand = User.token + " " + token;
+//            private static String description = "List the users on the server";
+//
+//            @Override
+//            public boolean isUserList() {
+//                return true;
+//            }
+//
+//            @Override
+//            public User.List asUserList() {
+//                return this;
+//            }
+//        }
+//
+//        public static class Create extends REPLCommand.User {
+//
+//            public static String token = "create";
+//            private static String helpCommand = User.token + " " + token + " " + "<username>";
+//            private static String description = "Create a user with name <username> and a supplied password on the server";
+//
+//            private final String user;
+//            private final String password;
+//
+//            public Create(String user, String password) {
+//                this.user = user;
+//                this.password = password;
+//            }
+//
+//            public String user() {
+//                return user;
+//            }
+//
+//            public String password() {
+//                return password;
+//            }
+//
+//            @Override
+//            public boolean isUserCreate() {
+//                return true;
+//            }
+//
+//            @Override
+//            public User.Create asUserCreate() {
+//                return this;
+//            }
+//        }
+//
+//        public static class PasswordUpdate extends REPLCommand.User {
+//
+//            public static String token = "password-update";
+//            private static String helpCommand = User.token + " " + token + " [old-password new-password]";
+//            private static String description = "Update the password of the current user";
+//
+//            private final String passwordOld;
+//            private final String passwordNew;
+//
+//            public PasswordUpdate(String passwordOld, String passwordNew) {
+//                this.passwordOld = passwordOld;
+//                this.passwordNew = passwordNew;
+//            }
+//
+//            public String passwordOld() {
+//                return passwordOld;
+//            }
+//
+//            public String passwordNew() {
+//                return passwordNew;
+//            }
+//
+//            @Override
+//            public boolean isUserPasswordUpdate() {
+//                return true;
+//            }
+//
+//            @Override
+//            public PasswordUpdate asUserPasswordUpdate() {
+//                return this;
+//            }
+//        }
+//
+//        public static class PasswordSet extends REPLCommand.User {
+//
+//            public static String token = "password-set";
+//            private static String helpCommand = User.token + " " + token + " " + "<username>";
+//            private static String description = "Set the password of user with name <username>";
+//
+//            private final String user;
+//
+//            private final String password;
+//
+//            public PasswordSet(String user, String password) {
+//                this.user = user;
+//                this.password = password;
+//            }
+//
+//            public String user() {
+//                return user;
+//            }
+//
+//            public String password() {
+//                return password;
+//            }
+//
+//            @Override
+//            public boolean isUserPasswordSet() {
+//                return true;
+//            }
+//
+//            @Override
+//            public PasswordSet asUserPasswordSet() {
+//                return this;
+//            }
+//        }
+//
+//        public static class Delete extends REPLCommand.User {
+//
+//            public static String token = "delete";
+//            private static String helpCommand = User.token + " " + token + " " + "<username>";
+//            private static String description = "Delete a user with name <username> on the server";
+//
+//            private final String user;
+//
+//            public Delete(String user) {
+//                this.user = user;
+//            }
+//
+//            public String user() {
+//                return user;
+//            }
+//
+//            @Override
+//            public boolean isUserDelete() {
+//                return true;
+//            }
+//
+//            @Override
+//            public User.Delete asUserDelete() {
+//                return this;
+//            }
+//        }
+//    }
 
     class Transaction implements REPLCommand {
 
         public static final String token = "transaction";
-        private static final String helpCommand = token + " <db> schema|data read|write [" + Options.token + "]";
-        private static final String description = "Start a transaction to database <db> with schema or data session, with read or write transaction";
+//        private static final String helpCommand = token + " <db> read|write|schema [" + Options.token + "]";
+        private static final String helpCommand = token + " <db> read|write|schema";
+        private static final String description = "Start a read, write, or schema transaction to database <db>";
 
         private final String database;
         private final TypeDBTransaction.Type transactionType;
-        private final TypeDBOptions options;
+//        private final TypeDBOptions options;
 
-        public Transaction(String database, TypeDBTransaction.Type transactionType, TypeDBOptions options) {
+        public Transaction(String database, TypeDBTransaction.Type transactionType/*, TypeDBOptions options*/) {
             this.database = database;
             this.transactionType = transactionType;
-            this.options = options;
+//            this.options = options;
         }
 
         public String database() {
@@ -494,9 +491,9 @@ public interface REPLCommand {
             return transactionType;
         }
 
-        public TypeDBOptions options() {
-            return options;
-        }
+//        public TypeDBOptions options() {
+//            return options;
+//        }
 
         @Override
         public boolean isTransaction() {
@@ -510,202 +507,197 @@ public interface REPLCommand {
 
     }
 
-    class Options {
-
-        public static String token = "transaction-options";
-
-        static TypeDBOptions from(String[] optionTokens, boolean isCloud) {
-            if (isCloud) return parseCloudOptions(optionTokens, new TypeDBOptions());
-            else return parseCoreOptions(optionTokens, new TypeDBOptions());
-        }
-
-        private static TypeDBOptions parseCloudOptions(String[] optionTokens, TypeDBOptions options) {
-            for (int i = 0; i < optionTokens.length; i += 2) {
-                String token = optionTokens[i];
-                String arg = optionTokens[i + 1];
-                assert token.charAt(0) == '-' && token.charAt(1) == '-';
-                Option<TypeDBOptions> option = Options.Cloud.cloudOption(token.substring(2));
-                try {
-                    options = option.build(options, arg);
-                } catch (IllegalArgumentException e) {
-                    throw new TypeDBConsoleException(e);
-                }
-            }
-            return options;
-        }
-
-        private static TypeDBOptions parseCoreOptions(String[] optionTokens, TypeDBOptions options) {
-            for (int i = 0; i < optionTokens.length; i += 2) {
-                String token = optionTokens[i];
-                String arg = optionTokens[i + 1];
-                assert token.charAt(0) == '-' && token.charAt(1) == '-';
-                Option<TypeDBOptions> option = Options.Core.coreOption(token.substring(2));
-                try {
-                    options = option.build(options, arg);
-                } catch (IllegalArgumentException e) {
-                    throw new TypeDBConsoleException(e);
-                }
-            }
-            return options;
-        }
-
-        static class Core {
-
-            static List<Option.Core> options = list(
-                    Option.core("infer", Option.Arg.BOOLEAN, "Enable or disable inference", (opt, arg) -> opt.infer((Boolean) arg)),
-                    Option.core("trace-inference", Option.Arg.BOOLEAN, "Enable or disable inference tracing", (opt, arg) -> opt.traceInference((Boolean) arg)),
-                    Option.core("explain", Option.Arg.BOOLEAN, "Enable or disable inference explanations", (opt, arg) -> opt.explain((Boolean) arg)),
-                    Option.core("parallel", Option.Arg.BOOLEAN, "Enable or disable parallel query execution", (opt, arg) -> opt.parallel((Boolean) arg)),
-                    Option.core("batch-size", Option.Arg.INTEGER, "Set RPC answer batch size", (opt, arg) -> opt.prefetchSize((Integer) arg)),
-                    Option.core("prefetch", Option.Arg.BOOLEAN, "Enable or disable RPC answer prefetch ", (opt, arg) -> opt.prefetch((Boolean) arg)),
-                    Option.core("session-idle-timeout", Option.Arg.INTEGER, "Kill idle session timeout (ms)", (opt, arg) -> opt.sessionIdleTimeoutMillis((Integer) arg)),
-                    Option.core("transaction-timeout", Option.Arg.INTEGER, "Kill transaction timeout (ms)", (opt, arg) -> opt.transactionTimeoutMillis((Integer) arg)),
-                    Option.core("schema-lock-acquire-timeout", Option.Arg.INTEGER, "Acquire exclusive schema session timeout (ms)", (opt, arg) -> opt.schemaLockAcquireTimeoutMillis((Integer) arg))
-            );
-
-            public static Option<TypeDBOptions> coreOption(String token) throws IllegalArgumentException {
-                return from(token, options);
-            }
-
-            public static List<Pair<String, String>> helpMenu() {
-                return helpMenu(options);
-            }
-
-            static <OPT extends TypeDBOptions> Option<OPT> from(String token, List<? extends Option<OPT>> options) {
-                for (Option<OPT> option : options) {
-                    if (option.name().equals(token)) return option;
-                }
-                throw new IllegalArgumentException(String.format("Unrecognized Option '%s'", token));
-            }
-
-            static List<Pair<String, String>> helpMenu(List<? extends Option<? extends TypeDBOptions>> options) {
-                List<Pair<String, String>> optionsMenu = new ArrayList<>();
-                optionsMenu.add(pair("transaction-options", "Transaction options"));
-                for (Option<? extends TypeDBOptions> option : options) {
-                    optionsMenu.add(pair("--" + option.name() + " " + option.arg().readableString(), option.description()));
-                }
-                return optionsMenu;
-            }
-        }
-
-        static class Cloud extends Core {
-
-            private static List<Option.Cloud> options = withCoreOptions(
-                    Option.cloud("read-any-replica", Option.Arg.BOOLEAN, "Allow (possibly stale) reads from any replica", (opt, arg) -> opt.readAnyReplica((Boolean) arg))
-            );
-
-            private static List<Option.Cloud> withCoreOptions(Option.Cloud... cloudOptions) {
-                List<Option.Cloud> extendedOptions = new ArrayList<>();
-                Core.options.forEach(opt -> extendedOptions.add(opt.asCloudOption()));
-                extendedOptions.addAll(Arrays.asList(cloudOptions));
-                return extendedOptions;
-            }
-
-            public static Option<TypeDBOptions> cloudOption(String token) throws IllegalArgumentException {
-                return from(token, options);
-            }
-
-            public static List<Pair<String, String>> helpMenu() {
-                return helpMenu(options);
-            }
-        }
-
-        static abstract class Option<OPTIONS extends TypeDBOptions> {
-
-            final String name;
-            final Arg arg;
-            final String description;
-            BiFunction<OPTIONS, Object, OPTIONS> builder;
-
-            private Option(String name, Arg arg, String description, BiFunction<OPTIONS, Object, OPTIONS> builder) {
-                this.name = name;
-                this.arg = arg;
-                this.description = description;
-                this.builder = builder;
-            }
-
-            static Option.Core core(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
-                return new Option.Core(name, arg, description, builder);
-            }
-
-            static Option.Cloud cloud(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
-                return new Option.Cloud(name, arg, description, builder);
-            }
-
-            OPTIONS build(OPTIONS options, String arg) {
-                return builder.apply(options, this.arg.parse(arg));
-            }
-
-            public String name() { return name; }
-
-            public Arg arg() { return arg; }
-
-            public String description() { return description; }
-
-            static class Core extends Option<TypeDBOptions> {
-
-                private Core(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
-                    super(name, arg, description, builder);
-                }
-
-                Option.Cloud asCloudOption() {
-                    return new Option.Cloud(name, arg, description, (cloudOption, arg) -> builder.apply(cloudOption, arg));
-                }
-            }
-
-            static class Cloud extends Option<TypeDBOptions> {
-
-                private Cloud(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
-                    super(name, arg, description, builder);
-                }
-            }
-
-            enum Arg {
-
-                BOOLEAN("true|false"),
-                INTEGER("1..[max int]");
-
-                private final String readableString;
-
-                Arg(String readableString) {
-                    this.readableString = readableString;
-                }
-
-                public String readableString() { return readableString; }
-
-                Object parse(String arg) throws IllegalArgumentException {
-                    if (this == BOOLEAN) return Boolean.parseBoolean(arg);
-                    else if (this == INTEGER) return Integer.parseInt(arg);
-                    else throw new IllegalArgumentException("Unrecognized option argument type: " + this.name());
-                }
-            }
-        }
-    }
+//    class Options {
+//
+//        public static String token = "transaction-options";
+//
+//        static TypeDBOptions from(String[] optionTokens, boolean isCloud) {
+////            if (isCloud) return parseCloudOptions(optionTokens, new TypeDBOptions()); else
+//            return parseCoreOptions(optionTokens, new TypeDBOptions());
+//        }
+//
+//        private static TypeDBOptions parseCloudOptions(String[] optionTokens, TypeDBOptions options) {
+//            for (int i = 0; i < optionTokens.length; i += 2) {
+//                String token = optionTokens[i];
+//                String arg = optionTokens[i + 1];
+//                assert token.charAt(0) == '-' && token.charAt(1) == '-';
+//                Option<TypeDBOptions> option = Options.Cloud.cloudOption(token.substring(2));
+//                try {
+//                    options = option.build(options, arg);
+//                } catch (IllegalArgumentException e) {
+//                    throw new TypeDBConsoleException(e);
+//                }
+//            }
+//            return options;
+//        }
+//
+//        private static TypeDBOptions parseCoreOptions(String[] optionTokens, TypeDBOptions options) {
+//            for (int i = 0; i < optionTokens.length; i += 2) {
+//                String token = optionTokens[i];
+//                String arg = optionTokens[i + 1];
+//                assert token.charAt(0) == '-' && token.charAt(1) == '-';
+//                Option<TypeDBOptions> option = Options.Core.coreOption(token.substring(2));
+//                try {
+//                    options = option.build(options, arg);
+//                } catch (IllegalArgumentException e) {
+//                    throw new TypeDBConsoleException(e);
+//                }
+//            }
+//            return options;
+//        }
+//
+//        static class Core {
+//
+//            static List<Option.Core> options = list(
+//                    Option.core("parallel", Option.Arg.BOOLEAN, "Enable or disable parallel query execution", (opt, arg) -> opt.parallel((Boolean) arg)),
+//                    Option.core("batch-size", Option.Arg.INTEGER, "Set RPC answer batch size", (opt, arg) -> opt.prefetchSize((Integer) arg)),
+//                    Option.core("prefetch", Option.Arg.BOOLEAN, "Enable or disable RPC answer prefetch ", (opt, arg) -> opt.prefetch((Boolean) arg)),
+//                    Option.core("transaction-timeout", Option.Arg.INTEGER, "Kill transaction timeout (ms)", (opt, arg) -> opt.transactionTimeoutMillis((Integer) arg)),
+//                    Option.core("schema-lock-acquire-timeout", Option.Arg.INTEGER, "Acquire exclusive schema session timeout (ms)", (opt, arg) -> opt.schemaLockAcquireTimeoutMillis((Integer) arg))
+//            );
+//
+//            public static Option<TypeDBOptions> coreOption(String token) throws IllegalArgumentException {
+//                return from(token, options);
+//            }
+//
+//            public static List<Pair<String, String>> helpMenu() {
+//                return helpMenu(options);
+//            }
+//
+//            static <OPT extends TypeDBOptions> Option<OPT> from(String token, List<? extends Option<OPT>> options) {
+//                for (Option<OPT> option : options) {
+//                    if (option.name().equals(token)) return option;
+//                }
+//                throw new IllegalArgumentException(String.format("Unrecognized Option '%s'", token));
+//            }
+//
+//            static List<Pair<String, String>> helpMenu(List<? extends Option<? extends TypeDBOptions>> options) {
+//                List<Pair<String, String>> optionsMenu = new ArrayList<>();
+//                optionsMenu.add(pair("transaction-options", "Transaction options"));
+//                for (Option<? extends TypeDBOptions> option : options) {
+//                    optionsMenu.add(pair("--" + option.name() + " " + option.arg().readableString(), option.description()));
+//                }
+//                return optionsMenu;
+//            }
+//        }
+//
+//        static class Cloud extends Core {
+//
+//            private static List<Option.Cloud> options = withCoreOptions(
+//                    Option.cloud("read-any-replica", Option.Arg.BOOLEAN, "Allow (possibly stale) reads from any replica", (opt, arg) -> opt.readAnyReplica((Boolean) arg))
+//            );
+//
+//            private static List<Option.Cloud> withCoreOptions(Option.Cloud... cloudOptions) {
+//                List<Option.Cloud> extendedOptions = new ArrayList<>();
+//                Core.options.forEach(opt -> extendedOptions.add(opt.asCloudOption()));
+//                extendedOptions.addAll(Arrays.asList(cloudOptions));
+//                return extendedOptions;
+//            }
+//
+//            public static Option<TypeDBOptions> cloudOption(String token) throws IllegalArgumentException {
+//                return from(token, options);
+//            }
+//
+//            public static List<Pair<String, String>> helpMenu() {
+//                return helpMenu(options);
+//            }
+//        }
+//
+//        static abstract class Option<OPTIONS extends TypeDBOptions> {
+//
+//            final String name;
+//            final Arg arg;
+//            final String description;
+//            BiFunction<OPTIONS, Object, OPTIONS> builder;
+//
+//            private Option(String name, Arg arg, String description, BiFunction<OPTIONS, Object, OPTIONS> builder) {
+//                this.name = name;
+//                this.arg = arg;
+//                this.description = description;
+//                this.builder = builder;
+//            }
+//
+//            static Option.Core core(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
+//                return new Option.Core(name, arg, description, builder);
+//            }
+//
+//            static Option.Cloud cloud(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
+//                return new Option.Cloud(name, arg, description, builder);
+//            }
+//
+//            OPTIONS build(OPTIONS options, String arg) {
+//                return builder.apply(options, this.arg.parse(arg));
+//            }
+//
+//            public String name() { return name; }
+//
+//            public Arg arg() { return arg; }
+//
+//            public String description() { return description; }
+//
+//            static class Core extends Option<TypeDBOptions> {
+//
+//                private Core(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
+//                    super(name, arg, description, builder);
+//                }
+//
+//                Option.Cloud asCloudOption() {
+//                    return new Option.Cloud(name, arg, description, (cloudOption, arg) -> builder.apply(cloudOption, arg));
+//                }
+//            }
+//
+//            static class Cloud extends Option<TypeDBOptions> {
+//
+//                private Cloud(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
+//                    super(name, arg, description, builder);
+//                }
+//            }
+//
+//            enum Arg {
+//
+//                BOOLEAN("true|false"),
+//                INTEGER("1..[max int]");
+//
+//                private final String readableString;
+//
+//                Arg(String readableString) {
+//                    this.readableString = readableString;
+//                }
+//
+//                public String readableString() { return readableString; }
+//
+//                Object parse(String arg) throws IllegalArgumentException {
+//                    if (this == BOOLEAN) return Boolean.parseBoolean(arg);
+//                    else if (this == INTEGER) return Integer.parseInt(arg);
+//                    else throw new IllegalArgumentException("Unrecognized option argument type: " + this.name());
+//                }
+//            }
+//        }
+//    }
 
     static String createHelpMenu(TypeDBDriver driver, boolean isCloud) {
-        List<Pair<String, String>> menu = new ArrayList<>();
-        if (driver.users() != null) {
-            menu.addAll(Arrays.asList(
-                    pair(User.List.helpCommand, User.List.description),
-                    pair(User.Create.helpCommand, User.Create.description),
-                    pair(User.PasswordUpdate.helpCommand, User.PasswordUpdate.description),
-                    pair(User.PasswordSet.helpCommand, User.PasswordSet.description),
-                    pair(User.Delete.helpCommand, User.Delete.description)));
-        }
+        //        if (driver.users() != null) {
+//            menu.addAll(Arrays.asList(
+//                    pair(User.List.helpCommand, User.List.description),
+//                    pair(User.Create.helpCommand, User.Create.description),
+//                    pair(User.PasswordUpdate.helpCommand, User.PasswordUpdate.description),
+//                    pair(User.PasswordSet.helpCommand, User.PasswordSet.description),
+//                    pair(User.Delete.helpCommand, User.Delete.description)));
+//        }
 
-        menu.addAll(Arrays.asList(
+        List<Pair<String, String>> menu = new ArrayList<>(Arrays.asList(
                 pair(Database.List.helpCommand, Database.List.description),
                 pair(Database.Create.helpCommand, Database.Create.description),
                 pair(Database.Delete.helpCommand, Database.Delete.description),
                 pair(Database.Schema.helpCommand, Database.Schema.description)));
 
-        if (isCloud) {
-            menu.add(pair(Database.Replicas.helpCommand, Database.Replicas.description));
-        }
+//        if (isCloud) {
+//            menu.add(pair(Database.Replicas.helpCommand, Database.Replicas.description));
+//        }
 
         menu.add(pair(Transaction.helpCommand, Transaction.description));
-        if (isCloud) menu.addAll(Options.Cloud.helpMenu());
-        else menu.addAll(Options.Core.helpMenu());
+//        if (isCloud) menu.addAll(Options.Cloud.helpMenu()); else
+//        menu.addAll(Options.Core.helpMenu());
 
         menu.addAll(Arrays.asList(
                 pair(Help.helpCommand, Help.description),
@@ -737,33 +729,33 @@ public interface REPLCommand {
             command = new Help();
         } else if (tokens.length == 1 && tokens[0].equals(Clear.token)) {
             command = new Clear();
-        } else if (tokens.length == 2 && tokens[0].equals(User.token) && tokens[1].equals(User.List.token)) {
-            command = new User.List();
-        } else if (tokens.length == 3 && tokens[0].equals(User.token) && tokens[1].equals(User.Create.token)) {
-            String name = tokens[2];
-            if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
-            String password = Utils.readPassword(passwordReader, "Password: ");
-            command = new User.Create(name, password);
-        } else if ((tokens.length == 2 || tokens.length == 4) && tokens[0].equals(User.token) && tokens[1].equals(User.PasswordUpdate.token)) {
-            String passwordOld;
-            String passwordNew;
-            if (tokens.length == 2) {
-                if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
-                passwordOld = Utils.readPassword(passwordReader, "Old password: ");
-                passwordNew = Utils.readPassword(passwordReader, "New password: ");
-            } else {
-                passwordOld = tokens[2];
-                passwordNew = tokens[3];
-            }
-            command = new User.PasswordUpdate(passwordOld, passwordNew);
-        } else if (tokens.length == 3 && tokens[0].equals(User.token) && tokens[1].equals(User.PasswordSet.token)) {
-            String name = tokens[2];
-            if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
-            String newPassword = Utils.readPassword(passwordReader, "New password: ");
-            command = new User.PasswordSet(name, newPassword);
-        } else if (tokens.length == 3 && tokens[0].equals(User.token) && tokens[1].equals(User.Delete.token)) {
-            String name = tokens[2];
-            command = new User.Delete(name);
+//        } else if (tokens.length == 2 && tokens[0].equals(User.token) && tokens[1].equals(User.List.token)) {
+//            command = new User.List();
+//        } else if (tokens.length == 3 && tokens[0].equals(User.token) && tokens[1].equals(User.Create.token)) {
+//            String name = tokens[2];
+//            if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
+//            String password = Utils.readPassword(passwordReader, "Password: ");
+//            command = new User.Create(name, password);
+//        } else if ((tokens.length == 2 || tokens.length == 4) && tokens[0].equals(User.token) && tokens[1].equals(User.PasswordUpdate.token)) {
+//            String passwordOld;
+//            String passwordNew;
+//            if (tokens.length == 2) {
+//                if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
+//                passwordOld = Utils.readPassword(passwordReader, "Old password: ");
+//                passwordNew = Utils.readPassword(passwordReader, "New password: ");
+//            } else {
+//                passwordOld = tokens[2];
+//                passwordNew = tokens[3];
+//            }
+//            command = new User.PasswordUpdate(passwordOld, passwordNew);
+//        } else if (tokens.length == 3 && tokens[0].equals(User.token) && tokens[1].equals(User.PasswordSet.token)) {
+//            String name = tokens[2];
+//            if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
+//            String newPassword = Utils.readPassword(passwordReader, "New password: ");
+//            command = new User.PasswordSet(name, newPassword);
+//        } else if (tokens.length == 3 && tokens[0].equals(User.token) && tokens[1].equals(User.Delete.token)) {
+//            String name = tokens[2];
+//            command = new User.Delete(name);
         } else if (tokens.length == 2 && tokens[0].equals(Database.token) && tokens[1].equals(Database.List.token)) {
             command = new Database.List();
         } else if (tokens.length == 3 && tokens[0].equals(Database.token) && tokens[1].equals(Database.Create.token)) {
@@ -775,17 +767,17 @@ public interface REPLCommand {
         } else if (tokens.length == 3 && tokens[0].equals(Database.token) && tokens[1].equals(Database.Schema.token)) {
             String database = tokens[2];
             command = new Database.Schema(database);
-        } else if (tokens.length == 3 && tokens[0].equals(Database.token) && tokens[1].equals(Database.Replicas.token)) {
-            String database = tokens[2];
-            command = new Database.Replicas(database);
+//        } else if (tokens.length == 3 && tokens[0].equals(Database.token) && tokens[1].equals(Database.Replicas.token)) {
+//            String database = tokens[2];
+//            command = new Database.Replicas(database);
         } else if (tokens.length >= 3 && tokens[0].equals(Transaction.token) &&
                 (tokens[2].equals("write") || tokens[2].equals("read") || tokens[2].equals("schema"))) {
             String database = tokens[1];
             TypeDBTransaction.Type transactionType = tokens[2].equals("write") ? TypeDBTransaction.Type.WRITE : tokens[2].equals("read") ? TypeDBTransaction.Type.READ : TypeDBTransaction.Type.SCHEMA;
-            TypeDBOptions options;
-            if (tokens.length > 3) options = Options.from(Arrays.copyOfRange(tokens, 3, tokens.length), isCloud);
-            else options = new TypeDBOptions();
-            command = new Transaction(database, transactionType, options);
+//            TypeDBOptions options;
+//            if (tokens.length > 3) options = Options.from(Arrays.copyOfRange(tokens, 3, tokens.length), isCloud);
+//            else options = new TypeDBOptions();
+            command = new Transaction(database, transactionType/*, options*/);
         }
         return command;
     }

--- a/command/REPLCommand.java
+++ b/command/REPLCommand.java
@@ -8,7 +8,6 @@ package com.vaticle.typedb.console.command;
 
 import com.vaticle.typedb.driver.api.TypeDBDriver;
 import com.vaticle.typedb.driver.api.TypeDBOptions;
-import com.vaticle.typedb.driver.api.TypeDBSession;
 import com.vaticle.typedb.driver.api.TypeDBTransaction;
 import com.vaticle.typedb.common.collection.Pair;
 import com.vaticle.typedb.console.common.Printer;
@@ -478,23 +477,17 @@ public interface REPLCommand {
         private static final String description = "Start a transaction to database <db> with schema or data session, with read or write transaction";
 
         private final String database;
-        private final TypeDBSession.Type sessionType;
         private final TypeDBTransaction.Type transactionType;
         private final TypeDBOptions options;
 
-        public Transaction(String database, TypeDBSession.Type sessionType, TypeDBTransaction.Type transactionType, TypeDBOptions options) {
+        public Transaction(String database, TypeDBTransaction.Type transactionType, TypeDBOptions options) {
             this.database = database;
-            this.sessionType = sessionType;
             this.transactionType = transactionType;
             this.options = options;
         }
 
         public String database() {
             return database;
-        }
-
-        public TypeDBSession.Type sessionType() {
-            return sessionType;
         }
 
         public TypeDBTransaction.Type transactionType() {
@@ -785,15 +778,14 @@ public interface REPLCommand {
         } else if (tokens.length == 3 && tokens[0].equals(Database.token) && tokens[1].equals(Database.Replicas.token)) {
             String database = tokens[2];
             command = new Database.Replicas(database);
-        } else if (tokens.length >= 4 && tokens[0].equals(Transaction.token) &&
-                (tokens[2].equals("schema") || tokens[2].equals("data")) && (tokens[3].equals("read") || tokens[3].equals("write"))) {
+        } else if (tokens.length >= 3 && tokens[0].equals(Transaction.token) &&
+                (tokens[2].equals("write") || tokens[2].equals("read") || tokens[2].equals("schema"))) {
             String database = tokens[1];
-            TypeDBSession.Type sessionType = tokens[2].equals("schema") ? TypeDBSession.Type.SCHEMA : TypeDBSession.Type.DATA;
-            TypeDBTransaction.Type transactionType = tokens[3].equals("read") ? TypeDBTransaction.Type.READ : TypeDBTransaction.Type.WRITE;
+            TypeDBTransaction.Type transactionType = tokens[2].equals("write") ? TypeDBTransaction.Type.WRITE : tokens[2].equals("read") ? TypeDBTransaction.Type.READ : TypeDBTransaction.Type.SCHEMA;
             TypeDBOptions options;
-            if (tokens.length > 4) options = Options.from(Arrays.copyOfRange(tokens, 4, tokens.length), isCloud);
+            if (tokens.length > 3) options = Options.from(Arrays.copyOfRange(tokens, 3, tokens.length), isCloud);
             else options = new TypeDBOptions();
-            command = new Transaction(database, sessionType, transactionType, options);
+            command = new Transaction(database, transactionType, options);
         }
         return command;
     }

--- a/command/REPLCommand.java
+++ b/command/REPLCommand.java
@@ -10,8 +10,7 @@ import com.vaticle.typedb.common.collection.Pair;
 import com.vaticle.typedb.console.common.Printer;
 import com.vaticle.typedb.console.common.Utils;
 import com.vaticle.typedb.console.common.exception.TypeDBConsoleException;
-import com.vaticle.typedb.driver.api.TypeDBDriver;
-import com.vaticle.typedb.driver.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.api.Driver;
 import org.jline.reader.LineReader;
 
 import javax.annotation.Nullable;
@@ -21,6 +20,9 @@ import java.util.List;
 
 import static com.vaticle.typedb.common.collection.Collections.pair;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
+import static com.vaticle.typedb.driver.api.Transaction.Type.READ;
+import static com.vaticle.typedb.driver.api.Transaction.Type.SCHEMA;
+import static com.vaticle.typedb.driver.api.Transaction.Type.WRITE;
 
 public interface REPLCommand {
 
@@ -474,10 +476,10 @@ public interface REPLCommand {
         private static final String description = "Start a read, write, or schema transaction to database <db>";
 
         private final String database;
-        private final TypeDBTransaction.Type transactionType;
-//        private final TypeDBOptions options;
+        private final com.vaticle.typedb.driver.api.Transaction.Type transactionType;
+//        private final Options options;
 
-        public Transaction(String database, TypeDBTransaction.Type transactionType/*, TypeDBOptions options*/) {
+        public Transaction(String database, com.vaticle.typedb.driver.api.Transaction.Type transactionType/*, Options options*/) {
             this.database = database;
             this.transactionType = transactionType;
 //            this.options = options;
@@ -487,11 +489,11 @@ public interface REPLCommand {
             return database;
         }
 
-        public TypeDBTransaction.Type transactionType() {
+        public com.vaticle.typedb.driver.api.Transaction.Type transactionType() {
             return transactionType;
         }
 
-//        public TypeDBOptions options() {
+//        public Options options() {
 //            return options;
 //        }
 
@@ -511,17 +513,17 @@ public interface REPLCommand {
 //
 //        public static String token = "transaction-options";
 //
-//        static TypeDBOptions from(String[] optionTokens, boolean isCloud) {
-////            if (isCloud) return parseCloudOptions(optionTokens, new TypeDBOptions()); else
-//            return parseCoreOptions(optionTokens, new TypeDBOptions());
+//        static Options from(String[] optionTokens, boolean isCloud) {
+////            if (isCloud) return parseCloudOptions(optionTokens, new Options()); else
+//            return parseCoreOptions(optionTokens, new Options());
 //        }
 //
-//        private static TypeDBOptions parseCloudOptions(String[] optionTokens, TypeDBOptions options) {
+//        private static Options parseCloudOptions(String[] optionTokens, Options options) {
 //            for (int i = 0; i < optionTokens.length; i += 2) {
 //                String token = optionTokens[i];
 //                String arg = optionTokens[i + 1];
 //                assert token.charAt(0) == '-' && token.charAt(1) == '-';
-//                Option<TypeDBOptions> option = Options.Cloud.cloudOption(token.substring(2));
+//                Option<Options> option = Options.Cloud.cloudOption(token.substring(2));
 //                try {
 //                    options = option.build(options, arg);
 //                } catch (IllegalArgumentException e) {
@@ -531,12 +533,12 @@ public interface REPLCommand {
 //            return options;
 //        }
 //
-//        private static TypeDBOptions parseCoreOptions(String[] optionTokens, TypeDBOptions options) {
+//        private static Options parseCoreOptions(String[] optionTokens, Options options) {
 //            for (int i = 0; i < optionTokens.length; i += 2) {
 //                String token = optionTokens[i];
 //                String arg = optionTokens[i + 1];
 //                assert token.charAt(0) == '-' && token.charAt(1) == '-';
-//                Option<TypeDBOptions> option = Options.Core.coreOption(token.substring(2));
+//                Option<Options> option = Options.Core.coreOption(token.substring(2));
 //                try {
 //                    options = option.build(options, arg);
 //                } catch (IllegalArgumentException e) {
@@ -556,7 +558,7 @@ public interface REPLCommand {
 //                    Option.core("schema-lock-acquire-timeout", Option.Arg.INTEGER, "Acquire exclusive schema session timeout (ms)", (opt, arg) -> opt.schemaLockAcquireTimeoutMillis((Integer) arg))
 //            );
 //
-//            public static Option<TypeDBOptions> coreOption(String token) throws IllegalArgumentException {
+//            public static Option<Options> coreOption(String token) throws IllegalArgumentException {
 //                return from(token, options);
 //            }
 //
@@ -564,17 +566,17 @@ public interface REPLCommand {
 //                return helpMenu(options);
 //            }
 //
-//            static <OPT extends TypeDBOptions> Option<OPT> from(String token, List<? extends Option<OPT>> options) {
+//            static <OPT extends Options> Option<OPT> from(String token, List<? extends Option<OPT>> options) {
 //                for (Option<OPT> option : options) {
 //                    if (option.name().equals(token)) return option;
 //                }
 //                throw new IllegalArgumentException(String.format("Unrecognized Option '%s'", token));
 //            }
 //
-//            static List<Pair<String, String>> helpMenu(List<? extends Option<? extends TypeDBOptions>> options) {
+//            static List<Pair<String, String>> helpMenu(List<? extends Option<? extends Options>> options) {
 //                List<Pair<String, String>> optionsMenu = new ArrayList<>();
 //                optionsMenu.add(pair("transaction-options", "Transaction options"));
-//                for (Option<? extends TypeDBOptions> option : options) {
+//                for (Option<? extends Options> option : options) {
 //                    optionsMenu.add(pair("--" + option.name() + " " + option.arg().readableString(), option.description()));
 //                }
 //                return optionsMenu;
@@ -594,7 +596,7 @@ public interface REPLCommand {
 //                return extendedOptions;
 //            }
 //
-//            public static Option<TypeDBOptions> cloudOption(String token) throws IllegalArgumentException {
+//            public static Option<Options> cloudOption(String token) throws IllegalArgumentException {
 //                return from(token, options);
 //            }
 //
@@ -603,7 +605,7 @@ public interface REPLCommand {
 //            }
 //        }
 //
-//        static abstract class Option<OPTIONS extends TypeDBOptions> {
+//        static abstract class Option<OPTIONS extends Options> {
 //
 //            final String name;
 //            final Arg arg;
@@ -617,11 +619,11 @@ public interface REPLCommand {
 //                this.builder = builder;
 //            }
 //
-//            static Option.Core core(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
+//            static Option.Core core(String name, Arg arg, String description, BiFunction<Options, Object, Options> builder) {
 //                return new Option.Core(name, arg, description, builder);
 //            }
 //
-//            static Option.Cloud cloud(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
+//            static Option.Cloud cloud(String name, Arg arg, String description, BiFunction<Options, Object, Options> builder) {
 //                return new Option.Cloud(name, arg, description, builder);
 //            }
 //
@@ -635,9 +637,9 @@ public interface REPLCommand {
 //
 //            public String description() { return description; }
 //
-//            static class Core extends Option<TypeDBOptions> {
+//            static class Core extends Option<Options> {
 //
-//                private Core(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
+//                private Core(String name, Arg arg, String description, BiFunction<Options, Object, Options> builder) {
 //                    super(name, arg, description, builder);
 //                }
 //
@@ -646,9 +648,9 @@ public interface REPLCommand {
 //                }
 //            }
 //
-//            static class Cloud extends Option<TypeDBOptions> {
+//            static class Cloud extends Option<Options> {
 //
-//                private Cloud(String name, Arg arg, String description, BiFunction<TypeDBOptions, Object, TypeDBOptions> builder) {
+//                private Cloud(String name, Arg arg, String description, BiFunction<Options, Object, Options> builder) {
 //                    super(name, arg, description, builder);
 //                }
 //            }
@@ -675,7 +677,7 @@ public interface REPLCommand {
 //        }
 //    }
 
-    static String createHelpMenu(TypeDBDriver driver, boolean isCloud) {
+    static String createHelpMenu(Driver driver, boolean isCloud) {
         //        if (driver.users() != null) {
 //            menu.addAll(Arrays.asList(
 //                    pair(User.List.helpCommand, User.List.description),
@@ -773,10 +775,10 @@ public interface REPLCommand {
         } else if (tokens.length >= 3 && tokens[0].equals(Transaction.token) &&
                 (tokens[2].equals("write") || tokens[2].equals("read") || tokens[2].equals("schema"))) {
             String database = tokens[1];
-            TypeDBTransaction.Type transactionType = tokens[2].equals("write") ? TypeDBTransaction.Type.WRITE : tokens[2].equals("read") ? TypeDBTransaction.Type.READ : TypeDBTransaction.Type.SCHEMA;
-//            TypeDBOptions options;
+            com.vaticle.typedb.driver.api.Transaction.Type transactionType = tokens[2].equals("write") ? WRITE : tokens[2].equals("read") ? READ : SCHEMA;
+//            Options options;
 //            if (tokens.length > 3) options = Options.from(Arrays.copyOfRange(tokens, 3, tokens.length), isCloud);
-//            else options = new TypeDBOptions();
+//            else options = new Options();
             command = new Transaction(database, transactionType/*, options*/);
         }
         return command;

--- a/common/Printer.java
+++ b/common/Printer.java
@@ -36,7 +36,7 @@ public class Printer {
 
     public static final String QUERY_SUCCESS = "Success";
     public static final String QUERY_COMPILATION_SUCCESS = "Completed validation and compilation...";
-    public static final String QUERY_WRITE_SUCCESS = "Completed writes...";
+    public static final String QUERY_WRITE_SUCCESS = "Finished writes";
     public static final String QUERY_STREAMING_ANSWERS = "Streaming answers...";
     public static final String TOTAL_ANSWERS = "Total answers: ";
 
@@ -98,7 +98,7 @@ public class Printer {
 
         if (queryType.isWrite()) {
             sb.append(QUERY_WRITE_SUCCESS);
-            sb.append("\n");
+            sb.append(". ");
         }
 
         assert !queryType.isSchema(); // expected to return another type of answer

--- a/common/Printer.java
+++ b/common/Printer.java
@@ -32,13 +32,15 @@ import static com.vaticle.typedb.console.common.exception.ErrorMessage.Internal.
 import static java.util.stream.Collectors.joining;
 
 public class Printer {
-    private static final int TABLE_DASHES = 6;
+    private static final int TABLE_DASHES = 7;
 
     public static final String QUERY_SUCCESS = "Success";
     public static final String QUERY_COMPILATION_SUCCESS = "Finished validation and compilation...";
     public static final String QUERY_WRITE_SUCCESS = "Finished writes";
     public static final String QUERY_STREAMING_ANSWERS = "Streaming answers...";
     public static final String TOTAL_ANSWERS = "Total answers: ";
+    private static final String TABLE_INDENT = "   ";
+    private static final String CONTENT_INDENT = "    ";
 
     private final PrintStream out;
     private final PrintStream err;
@@ -125,18 +127,18 @@ public class Printer {
                     return sb.toString();
                 }).collect(joining("\n"));
 
-        StringBuilder sb = new StringBuilder(indent(content));
+        StringBuilder sb = new StringBuilder(indent(CONTENT_INDENT, content));
         sb.append("\n");
         sb.append(lineDashSeparator(columnsWidth));
         return sb.toString();
     }
 
-    private static String indent(String string) {
-        return Arrays.stream(string.split("\n")).map(s -> "    " + s).collect(joining("\n"));
+    private static String indent(String indent, String string) {
+        return Arrays.stream(string.split("\n")).map(s -> indent + s).collect(joining("\n"));
     }
 
     private static String lineDashSeparator(int additionalDashesNum) {
-        return indent("-".repeat(TABLE_DASHES + additionalDashesNum));
+        return indent(TABLE_INDENT, "-".repeat(TABLE_DASHES + additionalDashesNum));
     }
 
     private String conceptDisplayString(Concept concept, Transaction tx) {

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -19,7 +19,7 @@
 @maven//:com_google_guava_failureaccess_1_0_1
 @maven//:com_google_guava_guava_30_1_jre
 @maven//:com_google_guava_listenablefuture_9999_0_empty_to_avoid_conflict_with_guava
-@maven//:com_google_http_client_google_http_client_1_34_2
+@maven//:com_google_http_client_google_http_client_1_41_4
 @maven//:com_google_http_client_google_http_client_gson_1_41_4
 @maven//:com_google_j2objc_j2objc_annotations_1_3
 @maven//:com_google_protobuf_protobuf_java_3_21_1
@@ -28,9 +28,6 @@
 @maven//:com_googlecode_java_diff_utils_diffutils_1_3_0
 @maven//:com_squareup_okhttp_okhttp_2_7_5
 @maven//:com_squareup_okio_okio_1_17_5
-@maven//:com_vaticle_typedb_typedb_cloud_runner_2_28_3
-@maven//:com_vaticle_typedb_typedb_common_2_28_1
-@maven//:com_vaticle_typedb_typedb_runner_2_28_3
 @maven//:com_vdurmont_semver4j_3_1_0
 @maven//:commons_codec_commons_codec_1_13
 @maven//:commons_io_commons_io_2_3
@@ -97,7 +94,7 @@
 @maven//:io_netty_netty_transport_udt_4_1_87_Final
 @maven//:io_opencensus_opencensus_api_0_24_0
 @maven//:io_opencensus_opencensus_contrib_grpc_metrics_0_24_0
-@maven//:io_opencensus_opencensus_contrib_http_util_0_24_0
+@maven//:io_opencensus_opencensus_contrib_http_util_0_31_0
 @maven//:io_perfmark_perfmark_api_0_25_0
 @maven//:io_sentry_sentry_7_1_0
 @maven//:javax_annotation_javax_annotation_api_1_3_2
@@ -105,8 +102,8 @@
 @maven//:net_jcip_jcip_annotations_1_0
 @maven//:org_antlr_antlr4_runtime_4_8
 @maven//:org_apache_commons_commons_lang3_3_9
-@maven//:org_apache_httpcomponents_httpclient_4_5_11
-@maven//:org_apache_httpcomponents_httpcore_4_4_13
+@maven//:org_apache_httpcomponents_httpclient_4_5_13
+@maven//:org_apache_httpcomponents_httpcore_4_4_15
 @maven//:org_apache_tomcat_annotations_api_6_0_53
 @maven//:org_apiguardian_apiguardian_api_1_1_0
 @maven//:org_checkerframework_checker_compat_qual_2_5_5

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -8,7 +8,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "294ef724c3853c9851e1e0c6bc04e0470c724e10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "354a37284acf67bcd43eb32064745af61f0d31e3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_driver():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -16,7 +16,7 @@ def vaticle_typedb_driver():
         name = "vaticle_typedb_driver",
         path = "../typedb-driver",
     )
-#    git_repository(
+#    git_repository( # TODO: Put the merged driver here
 #        name = "vaticle_typedb_driver",
 #        remote = "https://github.com/vaticle/typedb-driver",
 #        commit = "c75330e84bb5d5b3a5451baac691d55cc4d971c5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -12,12 +12,8 @@ def vaticle_dependencies():
     )
 
 def vaticle_typedb_driver():
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_driver",
-        path = "../typedb-driver",
+        remote = "https://github.com/vaticle/typedb-driver",
+        commit = "9d60e68bbd5820c95279a121dcbdaebdaf80c28c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )
-#    git_repository( # TODO: Put the merged driver here
-#        name = "vaticle_typedb_driver",
-#        remote = "https://github.com/vaticle/typedb-driver",
-#        commit = "c75330e84bb5d5b3a5451baac691d55cc4d971c5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
-#    )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -15,5 +15,5 @@ def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/vaticle/typedb-driver",
-        commit = "9d60e68bbd5820c95279a121dcbdaebdaf80c28c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        commit = "a77c73e0c98c8dfc5feeddcd01ad3da7a4d4935d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -12,8 +12,12 @@ def vaticle_dependencies():
     )
 
 def vaticle_typedb_driver():
-    git_repository(
+    native.local_repository(
         name = "vaticle_typedb_driver",
-        remote = "https://github.com/vaticle/typedb-driver",
-        commit = "c75330e84bb5d5b3a5451baac691d55cc4d971c5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        path = "../typedb-driver",
     )
+#    git_repository(
+#        name = "vaticle_typedb_driver",
+#        remote = "https://github.com/vaticle/typedb-driver",
+#        commit = "c75330e84bb5d5b3a5451baac691d55cc4d971c5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+#    )

--- a/test/assembly/AssemblyTest.java
+++ b/test/assembly/AssemblyTest.java
@@ -18,22 +18,23 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.Assert.fail;
 
 public class AssemblyTest {
+    static final String DATABASE_NAME = "assembly-test-db";
 
     @Test
     public void test_console_command() throws IOException, InterruptedException, TimeoutException {
         TypeDBConsoleRunner consoleRunner = new TypeDBConsoleRunner();
-        TypeDBCoreRunner coreRunner = new TypeDBCoreRunner();
+//        TypeDBCoreRunner coreRunner = new TypeDBCoreRunner();
         try {
-            coreRunner.start();
-            int status = consoleRunner.run("--core", coreRunner.address(), "--command", "database create assembly-test-db");
+//            coreRunner.start();
+            int status = consoleRunner.run("--core", "127.0.0.1:1729", "--command", String.format("database create %s", DATABASE_NAME));
             if (status != 0) {
                fail("Console command returned non-zero exit status: " + status);
             }
         } catch (Exception e) {
             fail("Exception occurred while starting server and console runner." +  e);
-        } finally {
-            coreRunner.stop();
-            coreRunner.deleteFiles();
+//        } finally {
+//            coreRunner.stop();
+//            coreRunner.deleteFiles();
         }
     }
 }

--- a/test/assembly/AssemblyTest.java
+++ b/test/assembly/AssemblyTest.java
@@ -7,7 +7,7 @@
 package com.vaticle.typedb.console.test.assembly;
 
 import com.vaticle.typedb.console.tool.runner.TypeDBConsoleRunner;
-import com.vaticle.typedb.core.tool.runner.TypeDBCoreRunner;
+//import com.vaticle.typedb.core.tool.runner.TypeDBCoreRunner;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/test/assembly/BUILD
+++ b/test/assembly/BUILD
@@ -7,30 +7,29 @@ package(default_visibility = ["//visibility:__subpackages__"])
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@vaticle_dependencies//builder/java:rules.bzl", "typedb_java_test")
 
-#typedb_java_test(
-#    name = "test-assembly-native",
-#    test_class = "com.vaticle.typedb.console.test.assembly.AssemblyTest",
-#    srcs = ["AssemblyTest.java"],
-#    deps = [
-#        "//tool/runner:typedb-console-runner",
-#        "@maven//:com_vaticle_typedb_typedb_runner",
-#    ],
-#    server_artifacts = {
-#        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_artifact_linux-arm64//file",
-#        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_artifact_linux-x86_64//file",
-#        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_artifact_mac-arm64//file",
-#        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_artifact_mac-86_64//file",
-#        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_artifact_windows-x86_64//file",
-#    },
-#    console_artifacts = {
-#        "@vaticle_bazel_distribution//platform:is_linux_arm64": "//:assemble-linux-arm64-targz",
-#        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "//:assemble-linux-x86_64-targz",
-#        "@vaticle_bazel_distribution//platform:is_mac_arm64": "//:assemble-mac-arm64-zip",
-#        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "//:assemble-mac-x86_64-zip",
-#        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "//:assemble-windows-x86_64-zip",
-#    },
-#)
-
+typedb_java_test(
+    name = "test-assembly-native",
+    test_class = "com.vaticle.typedb.console.test.assembly.AssemblyTest",
+    srcs = ["AssemblyTest.java"],
+    deps = [
+        "//tool/runner:typedb-console-runner",
+        "@maven//:com_vaticle_typedb_typedb_runner",
+    ],
+    server_artifacts = {
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_artifact_linux-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_artifact_linux-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_artifact_mac-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_artifact_mac-86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_artifact_windows-x86_64//file",
+    },
+    console_artifacts = {
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "//:assemble-linux-arm64-targz",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "//:assemble-linux-x86_64-targz",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "//:assemble-mac-arm64-zip",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "//:assemble-mac-x86_64-zip",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "//:assemble-windows-x86_64-zip",
+    },
+)
 
 checkstyle_test(
     name = "checkstyle",

--- a/test/assembly/BUILD
+++ b/test/assembly/BUILD
@@ -7,29 +7,29 @@ package(default_visibility = ["//visibility:__subpackages__"])
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@vaticle_dependencies//builder/java:rules.bzl", "typedb_java_test")
 
-typedb_java_test(
-    name = "test-assembly-native",
-    test_class = "com.vaticle.typedb.console.test.assembly.AssemblyTest",
-    srcs = ["AssemblyTest.java"],
-    deps = [
-        "//tool/runner:typedb-console-runner",
-        "@maven//:com_vaticle_typedb_typedb_runner",
-    ],
-    server_artifacts = {
-        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_artifact_linux-arm64//file",
-        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_artifact_linux-x86_64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_artifact_mac-arm64//file",
-        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_artifact_mac-86_64//file",
-        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_artifact_windows-x86_64//file",
-    },
-    console_artifacts = {
-        "@vaticle_bazel_distribution//platform:is_linux_arm64": "//:assemble-linux-arm64-targz",
-        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "//:assemble-linux-x86_64-targz",
-        "@vaticle_bazel_distribution//platform:is_mac_arm64": "//:assemble-mac-arm64-zip",
-        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "//:assemble-mac-x86_64-zip",
-        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "//:assemble-windows-x86_64-zip",
-    },
-)
+#typedb_java_test(
+#    name = "test-assembly-native",
+#    test_class = "com.vaticle.typedb.console.test.assembly.AssemblyTest",
+#    srcs = ["AssemblyTest.java"],
+#    deps = [
+#        "//tool/runner:typedb-console-runner",
+#        "@maven//:com_vaticle_typedb_typedb_runner",
+#    ],
+#    server_artifacts = {
+#        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_artifact_linux-arm64//file",
+#        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_artifact_linux-x86_64//file",
+#        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_artifact_mac-arm64//file",
+#        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_artifact_mac-86_64//file",
+#        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_artifact_windows-x86_64//file",
+#    },
+#    console_artifacts = {
+#        "@vaticle_bazel_distribution//platform:is_linux_arm64": "//:assemble-linux-arm64-targz",
+#        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "//:assemble-linux-x86_64-targz",
+#        "@vaticle_bazel_distribution//platform:is_mac_arm64": "//:assemble-mac-arm64-zip",
+#        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "//:assemble-mac-x86_64-zip",
+#        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "//:assemble-windows-x86_64-zip",
+#    },
+#)
 
 
 checkstyle_test(

--- a/test/assembly/BUILD
+++ b/test/assembly/BUILD
@@ -13,7 +13,7 @@ typedb_java_test(
     srcs = ["AssemblyTest.java"],
     deps = [
         "//tool/runner:typedb-console-runner",
-        "@maven//:com_vaticle_typedb_typedb_runner",
+#        "@maven//:com_vaticle_typedb_typedb_runner",
     ],
     server_artifacts = {
         "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_artifact_linux-arm64//file",


### PR DESCRIPTION
## Usage and product changes
We refactor console to support the updated `typedb` of 3.0-alpha.

## Implementation
Non-existing features are deleted. Non-implemented features are commented out (cloud, user management, options). 

The new output looks like this: 
```
> database create its-my-pr
Database 'its-my-pr' created
> transaction its-my-pr schema
its-my-pr::schema> define
                   attribute name, value string;
                   entity person, owns name;
                   
Success
its-my-pr::schema> commit
Transaction changes committed
> transaction its-my-pr write
its-my-pr::write> insert $x isa person, has name "John"; $y isa person, has name "Alice";
                  
Finished validation and compilation...
Finished writes. Streaming answers...

   ---------
    $x | iid 0x1e00000000000000000000 isa person
    $y | iid 0x1e00000000000000000001 isa person
   ---------

Finished. Total answers: 1
its-my-pr::write> commit
Transaction changes committed
> transaction its-my-pr read
its-my-pr::read> match $x has name $a;
                 
Finished validation and compilation...
Streaming answers...

   ---------
    $a | Alice isa name
    $x | iid 0x1e00000000000000000001 isa person
   ---------
    $a | John isa name
    $x | iid 0x1e00000000000000000000 isa person
   ---------

Finished. Total answers: 2
```

The release pipeline should be the same. However, we may need to update the dependencies on typedb artifacts later in the following smaller prs.