### PR TITLE
Fix error throwing on password update

### DIFF
--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -215,10 +215,11 @@ public class TypeDBConsole {
                     runUserCreate(driver, command.asUserCreate().user(), command.asUserCreate().password());
                 } else if (command.isUserPasswordUpdate()) {
                     REPLCommand.User.PasswordUpdate userPasswordUpdate = command.asUserPasswordUpdate();
+                    String username = driver.users().getCurrentUser().name();
                     boolean passwordUpdateSuccessful = runUserPasswordUpdate(driver,
                             userPasswordUpdate.user(),
                             userPasswordUpdate.password());
-                    if (passwordUpdateSuccessful && userPasswordUpdate.user().equals(driver.users().getCurrentUser().name())) {
+                    if (passwordUpdateSuccessful && userPasswordUpdate.user().equals(username)) {
                         printer.info("Please login again with your updated password.");
                         break;
                     }
@@ -379,10 +380,11 @@ public class TypeDBConsole {
                         if (!success) return false;
                     } else if (command.isUserPasswordUpdate()) {
                         REPLCommand.User.PasswordUpdate userPasswordUpdate = command.asUserPasswordUpdate();
+                        String username = driver.users().getCurrentUser().name();
                         boolean passwordUpdateSuccessful = runUserPasswordUpdate(driver,
                                 userPasswordUpdate.user(),
                                 userPasswordUpdate.password());
-                        if (passwordUpdateSuccessful && userPasswordUpdate.user().equals(driver.users().getCurrentUser().name())) {
+                        if (passwordUpdateSuccessful && userPasswordUpdate.user().equals(username)) {
                             printer.info("Please login again with your updated password.");
                             break;
                         } else return false;


### PR DESCRIPTION
## Usage and product changes

We fix an issue that caused an error to be thrown by password update commands, in spite of them succeeding

## Implementation

We retrieve the current username before updating the password, so it no longer relies on the now deauthenticated connection.