### PR TITLE
Update the Driver dependency to work with optional concepts from rows

### DIFF
--- a/common/Printer.java
+++ b/common/Printer.java
@@ -26,6 +26,7 @@ import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.typedb.console.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
@@ -123,15 +124,13 @@ public class Printer {
                     sb.append(columnName);
                     sb.append(" ".repeat(columnsWidth - columnName.length() + 1));
                     sb.append("| ");
-                    Concept concept;
-                    try {
-                        concept = conceptRow.get(columnName);
+                    Optional<Concept> conceptOptional = conceptRow.get(columnName);
+                    if (conceptOptional.isPresent()) {
+                        Concept concept = conceptOptional.get();
                         sb.append(conceptDisplayString(concept.isValue() ? concept.asValue() : concept, tx));
-                    } catch (TypeDBDriverException e) {
-                        // TODO: substitute the "try catch" by an optional processing when implemented
                     }
                     return sb.toString();
-                }).filter(string -> !string.isEmpty()).collect(joining("\n"));
+                }).collect(joining("\n"));
 
         StringBuilder sb = new StringBuilder(indent(CONTENT_INDENT, content));
         sb.append("\n");

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -12,9 +12,8 @@ def typedb_dependencies():
     )
 
 def typedb_driver():
-    # TODO: Return typedb after merges
     git_repository(
         name = "typedb_driver",
-        remote = "https://github.com/farost/typedb-driver",
-        commit = "f1f0ac3725436cd180534f95b000ad8c04e79dc9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        remote = "https://github.com/typedb/typedb-driver",
+        commit = "c0653ca0615f4075492f0b098960d291468ebd91",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -12,8 +12,9 @@ def typedb_dependencies():
     )
 
 def typedb_driver():
+    # TODO: Return typedb after merges
     git_repository(
         name = "typedb_driver",
-        remote = "https://github.com/typedb/typedb-driver",
-        tag = "3.0.4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        remote = "https://github.com/farost/typedb-driver",
+        commit = "f1f0ac3725436cd180534f95b000ad8c04e79dc9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )


### PR DESCRIPTION
## Usage and product changes
Update the Driver dependency to work with optional concepts from rows.

## Implementation
Check the optional result and get its concept instead of a temporary `try {} catch` block.