### PR TITLE
Multiline script paste and unified scripting format

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ will also be autocompleted, while others, such as queries, will not.
   Finished schema query.
   >>
   ```
-- `source <file>` : Run TypeQL queries in a file, which you can refer to using relative or absolute path. Multiline TypeQL queries in these files must be indicated by using the backslash (\) character
+- `source <file>` : Run TypeQL queries in a file (_not a general console script_), which you can refer to using relative or absolute path. Queries must be terminated by an empty newline.
   ```
   my-typedb-database::schema> source ./schema.tql
   Successfully executed 1 queries.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ We can define a script file that contains the list of commands to run, then invo
 Script files take exactly the same format as scripts pasted directly in the REPL.
 Importantly, this means that the **end of a query is delimited by an empty newline**.
 
-For example, a script `commands.stql`
+For example, a script `commands.tqls`
 ```
 database create test
 transaction schema test
@@ -213,7 +213,7 @@ database delete test
 
 Will produce the following output:
 ```
-./typedb console --username="user" --password="password" --script=commands.stql     
+./typedb console --username="user" --password="password" --script=commands.tqls     
 + database create test
 Successfully created database.
 + transaction schema test

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,11 +14,11 @@ pub struct Args {
     #[arg(long, value_name = "command")]
     pub command: Vec<String>,
 
-    /// Executes all console commands directly from the file in the order of each specified file.
+    /// Executes all console commands directly from the script(s) in the order of each specified script.
     /// Exits if any script errors at any point.
-    /// Files can use backslashes ('\') to make execute multiple lines as a single command
-    #[arg(long, value_name = "path to file")]
-    pub file: Vec<String>,
+    /// Files must follow the convention of terminating queries with an empty newline
+    #[arg(long, value_name = "path to script file")]
+    pub script: Vec<String>,
 
     /// TypeDB address to connect to. If using TLS encryption, this must start with "https://"
     #[arg(long, value_name = "host:port")]

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -31,7 +31,7 @@ pub(crate) fn database_name_completer(
 }
 
 pub(crate) fn file_completer(input: &str) -> Vec<String> {
-    match glob(input) {
+    match glob(&format!("{}*", input)) {
         Ok(paths) => paths.filter_map(Result::ok).map(|path| path.to_string_lossy().into_owned()).collect(),
         Err(_) => Vec::new(),
     }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use glob::glob;
 use typedb_driver::TypeDBDriver;
 
-use crate::{BackgroundRuntime, repl::command::InputCompleterFn};
+use crate::{repl::command::InputCompleterFn, BackgroundRuntime};
 
 pub(crate) fn database_name_completer_fn(
     driver: Arc<TypeDBDriver>,

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use glob::glob;
 use typedb_driver::TypeDBDriver;
 
-use crate::{repl::command::InputCompleterFn, BackgroundRuntime};
+use crate::{BackgroundRuntime, repl::command::InputCompleterFn};
 
 pub(crate) fn database_name_completer_fn(
     driver: Arc<TypeDBDriver>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use crate::{
         user_delete, user_update_password,
     },
     repl::{
-        command::{get_all, get_word, CommandDefault, CommandInput, CommandOption, Subcommands},
+        command::{get_multiline_query, get_word, CommandDefault, CommandInput, CommandOption, Subcommands},
         line_reader::LineReaderHidden,
         Repl, ReplContext, ReplResult,
     },
@@ -313,7 +313,7 @@ fn transaction_repl(database: &str, transaction_type: TransactionType) -> Repl<C
         ))
         .add_default(CommandDefault::new(
             "Execute query string.",
-            CommandInput::new("query", get_all, None, None),
+            CommandInput::new("query", get_multiline_query, None, None),
             transaction_query,
         ));
     repl

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,6 @@ mod runtime;
 pub const VERSION: &str = include_str!("../VERSION");
 
 const PROMPT: &'static str = ">> ";
-const MULTILINE_INPUT_SYMBOL: &'static str = "\\";
 const ENTRY_REPL_HISTORY: &'static str = ".typedb_console_repl_history";
 const TRANSACTION_REPL_HISTORY: &'static str = "typedb_console_transaction_repl_history";
 const DIAGNOSTICS_REPORTING_URI: &'static str =

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,6 @@ fn execute_commands_all(
     coerce_to_one_line: bool,
     must_log_command: bool,
 ) -> Result<(), EmptyError> {
-    log(&format!("executing all commands from input: '{}'", input));
     let mut multiple_commands = None;
     while !context.repl_stack.is_empty() && !input.trim().is_empty() {
         let repl_index = context.repl_stack.len() - 1;
@@ -200,7 +199,6 @@ fn execute_commands_all(
             }
         };
         input = input.trim_start();
-        log(&format!("Finished processing command, remaining input: {}\n", input));
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::{
     fs::File,
     io,
     io::BufRead,
-    ops::{ControlFlow, ControlFlow::Continue},
+    ops::ControlFlow,
     path::Path,
     process::exit,
     rc::Rc,
@@ -20,10 +20,9 @@ use std::{
 
 use clap::Parser;
 use home::home_dir;
+use rustyline::error::ReadlineError;
 use sentry::ClientOptions;
 use typedb_driver::{Credentials, DriverOptions, Transaction, TransactionType, TypeDBDriver};
-use ControlFlow::Break;
-use rustyline::error::ReadlineError;
 
 use crate::{
     cli::Args,
@@ -34,13 +33,13 @@ use crate::{
         user_delete, user_update_password,
     },
     repl::{
-        command::{get_until_empty_line, get_word, CommandDefault, CommandInput, CommandLeaf, Subcommand},
+        command::{CommandDefault, CommandInput, CommandLeaf, get_until_empty_line, get_word, Subcommand},
         line_reader::LineReaderHidden,
         Repl, ReplContext, ReplResult,
     },
     runtime::BackgroundRuntime,
 };
-use crate::repl::command::{CommandResult, ExecutableCommand, log, ReplError};
+use crate::repl::command::{ExecutableCommand, log, ReplError};
 
 mod cli;
 mod completions;
@@ -201,7 +200,7 @@ fn execute_commands_all<'a>(context: &mut ConsoleContext, mut input: &'a str) ->
                 if multiple_commands.is_none() && !input[next_command_index..].trim().is_empty() {
                     multiple_commands = Some(true);
                 }
-
+                
                 if multiple_commands.is_some_and(|b| b) {
                     println!("{} {}", "+".repeat(repl_index + 1), command_string);
                 }
@@ -353,7 +352,8 @@ fn transaction_repl(database: &str, transaction_type: TransactionType) -> Repl<C
             CommandInput::new("file", get_word, None, Some(Box::new(file_completer))),
             transaction_source,
         ))
-        .add_default(CommandDefault::new(
+        .add(CommandLeaf::new_with_input(
+            "",
             "Execute query string.",
             CommandInput::new("query", get_until_empty_line, None, None),
             transaction_query,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use crate::{
         user_delete, user_update_password,
     },
     repl::{
-        command::{get_or_until_empty_line, get_word, log, CommandInput, CommandLeaf, ExecutableCommand, Subcommand},
+        command::{get_or_until_empty_line, get_word, CommandInput, CommandLeaf, Subcommand},
         line_reader::LineReaderHidden,
         Repl, ReplContext,
     },
@@ -148,7 +148,7 @@ fn execute_script(context: &mut ConsoleContext, file: &str, inputs: impl Iterato
         }
     }
     // we could choose to implement this as line-by-line instead of as an interactive-compatible script
-    execute_commands_all(context, &combined_input, false, true);
+    let _ = execute_commands_all(context, &combined_input, false, true);
 }
 
 fn execute_commands(context: &mut ConsoleContext, commands: &[String]) {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -13,9 +13,9 @@ use typedb_driver::{
 };
 
 use crate::{
-    printer::{print_document, print_row},
-    repl::{command::ReplError, ReplResult},
-    transaction_repl, ConsoleContext, MULTILINE_INPUT_SYMBOL,
+    ConsoleContext,
+    MULTILINE_INPUT_SYMBOL,
+    printer::{print_document, print_row}, repl::command::ReplError, transaction_repl,
 };
 use crate::repl::command::CommandResult;
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -13,13 +13,12 @@ use typedb_driver::{
 };
 
 use crate::{
-    ConsoleContext,
-    MULTILINE_INPUT_SYMBOL,
-    printer::{print_document, print_row}, repl::command::ReplError, transaction_repl,
+    printer::{print_document, print_row},
+    repl::command::{CommandResult, ReplError},
+    transaction_repl, ConsoleContext, MULTILINE_INPUT_SYMBOL,
 };
-use crate::repl::command::CommandResult;
 
-pub(crate) fn database_list(context: &mut ConsoleContext, _input: &[String])-> CommandResult {
+pub(crate) fn database_list(context: &mut ConsoleContext, _input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let databases = context
         .background_runtime
@@ -31,7 +30,7 @@ pub(crate) fn database_list(context: &mut ConsoleContext, _input: &[String])-> C
     Ok(())
 }
 
-pub(crate) fn database_create(context: &mut ConsoleContext, input: &[String])-> CommandResult {
+pub(crate) fn database_create(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let db_name = input[0].clone();
     context
@@ -42,7 +41,7 @@ pub(crate) fn database_create(context: &mut ConsoleContext, input: &[String])-> 
     Ok(())
 }
 
-pub(crate) fn database_delete(context: &mut ConsoleContext, input: &[String])-> CommandResult {
+pub(crate) fn database_delete(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let db_name = input[0].clone();
     context
@@ -56,7 +55,7 @@ pub(crate) fn database_delete(context: &mut ConsoleContext, input: &[String])-> 
     Ok(())
 }
 
-pub(crate) fn user_create(context: &mut ConsoleContext, input: &[String])-> CommandResult {
+pub(crate) fn user_create(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let username = input[0].clone();
     let password = input[1].clone();
@@ -68,7 +67,7 @@ pub(crate) fn user_create(context: &mut ConsoleContext, input: &[String])-> Comm
     Ok(())
 }
 
-pub(crate) fn user_delete(context: &mut ConsoleContext, input: &[String])-> CommandResult {
+pub(crate) fn user_delete(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let username = input[0].clone();
     context.background_runtime.run(async move {
@@ -87,7 +86,7 @@ pub(crate) fn user_delete(context: &mut ConsoleContext, input: &[String])-> Comm
     Ok(())
 }
 
-pub(crate) fn user_update_password(context: &mut ConsoleContext, input: &[String])-> CommandResult {
+pub(crate) fn user_update_password(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let username = input[0].clone();
     let new_password = input[1].clone();
@@ -119,7 +118,7 @@ pub(crate) fn user_update_password(context: &mut ConsoleContext, input: &[String
     Ok(())
 }
 
-pub(crate) fn transaction_read(context: &mut ConsoleContext, input: &[String])-> CommandResult {
+pub(crate) fn transaction_read(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let db_name = &input[0];
     let db_name_owned = db_name.clone();
@@ -133,7 +132,7 @@ pub(crate) fn transaction_read(context: &mut ConsoleContext, input: &[String])->
     Ok(())
 }
 
-pub(crate) fn transaction_write(context: &mut ConsoleContext, input: &[String])-> CommandResult {
+pub(crate) fn transaction_write(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let db_name = &input[0];
     let db_name_owned = db_name.clone();
@@ -147,7 +146,7 @@ pub(crate) fn transaction_write(context: &mut ConsoleContext, input: &[String])-
     Ok(())
 }
 
-pub(crate) fn transaction_schema(context: &mut ConsoleContext, input: &[String])-> CommandResult {
+pub(crate) fn transaction_schema(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let db_name = &input[0];
     let db_name_owned = db_name.clone();
@@ -161,7 +160,7 @@ pub(crate) fn transaction_schema(context: &mut ConsoleContext, input: &[String])
     Ok(())
 }
 
-pub(crate) fn transaction_commit(context: &mut ConsoleContext, _input: &[String])-> CommandResult {
+pub(crate) fn transaction_commit(context: &mut ConsoleContext, _input: &[String]) -> CommandResult {
     match context.background_runtime.run(context.transaction.take().unwrap().commit()) {
         Ok(_) => {
             println!("Successfully committed transaction.");
@@ -175,7 +174,7 @@ pub(crate) fn transaction_commit(context: &mut ConsoleContext, _input: &[String]
     }
 }
 
-pub(crate) fn transaction_close(context: &mut ConsoleContext, _input: &[String])-> CommandResult {
+pub(crate) fn transaction_close(context: &mut ConsoleContext, _input: &[String]) -> CommandResult {
     let transaction = context.transaction.take().unwrap(); // drop
     let message = match transaction.type_() {
         TransactionType::Read => "Transaction closed",
@@ -186,7 +185,7 @@ pub(crate) fn transaction_close(context: &mut ConsoleContext, _input: &[String])
     Ok(())
 }
 
-pub(crate) fn transaction_rollback(context: &mut ConsoleContext, _input: &[String])-> CommandResult {
+pub(crate) fn transaction_rollback(context: &mut ConsoleContext, _input: &[String]) -> CommandResult {
     let transaction = context.transaction.take().unwrap();
     let (transaction, result) = context.background_runtime.run(async move {
         let result = transaction.rollback().await;
@@ -206,7 +205,7 @@ pub(crate) fn transaction_rollback(context: &mut ConsoleContext, _input: &[Strin
     }
 }
 
-pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])-> CommandResult {
+pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let file_str = &input[0];
     let path = Path::new(file_str);
     if !path.exists() {
@@ -258,7 +257,7 @@ pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])
     Ok(())
 }
 
-pub(crate) fn transaction_query(context: &mut ConsoleContext, input: &[impl AsRef<str>])-> CommandResult {
+pub(crate) fn transaction_query(context: &mut ConsoleContext, input: &[impl AsRef<str>]) -> CommandResult {
     let query = input[0].as_ref().to_owned();
     execute_query(context, query, true).map_err(|err| Box::new(err) as Box<dyn Error + Send>)
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -4,13 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    error::Error,
-    fs::read_to_string,
-    path::Path,
-    process::exit,
-    rc::Rc,
-};
+use std::{error::Error, fs::read_to_string, path::Path, process::exit, rc::Rc};
 
 use futures::stream::StreamExt;
 use typedb_driver::{
@@ -19,8 +13,9 @@ use typedb_driver::{
 };
 
 use crate::{
-    ConsoleContext,
-    printer::{print_document, print_row}, repl::command::{CommandResult, get_to_empty_line, ReplError}, transaction_repl,
+    printer::{print_document, print_row},
+    repl::command::{get_to_empty_line, CommandResult, ReplError},
+    transaction_repl, ConsoleContext,
 };
 
 pub(crate) fn database_list(context: &mut ConsoleContext, _input: &[String]) -> CommandResult {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -17,8 +17,9 @@ use crate::{
     repl::{command::ReplError, ReplResult},
     transaction_repl, ConsoleContext, MULTILINE_INPUT_SYMBOL,
 };
+use crate::repl::command::CommandResult;
 
-pub(crate) fn database_list(context: &mut ConsoleContext, _input: &[String]) -> ReplResult {
+pub(crate) fn database_list(context: &mut ConsoleContext, _input: &[String])-> CommandResult {
     let driver = context.driver.clone();
     let databases = context
         .background_runtime
@@ -30,7 +31,7 @@ pub(crate) fn database_list(context: &mut ConsoleContext, _input: &[String]) -> 
     Ok(())
 }
 
-pub(crate) fn database_create(context: &mut ConsoleContext, input: &[String]) -> ReplResult {
+pub(crate) fn database_create(context: &mut ConsoleContext, input: &[String])-> CommandResult {
     let driver = context.driver.clone();
     let db_name = input[0].clone();
     context
@@ -41,7 +42,7 @@ pub(crate) fn database_create(context: &mut ConsoleContext, input: &[String]) ->
     Ok(())
 }
 
-pub(crate) fn database_delete(context: &mut ConsoleContext, input: &[String]) -> ReplResult {
+pub(crate) fn database_delete(context: &mut ConsoleContext, input: &[String])-> CommandResult {
     let driver = context.driver.clone();
     let db_name = input[0].clone();
     context
@@ -55,7 +56,7 @@ pub(crate) fn database_delete(context: &mut ConsoleContext, input: &[String]) ->
     Ok(())
 }
 
-pub(crate) fn user_create(context: &mut ConsoleContext, input: &[String]) -> ReplResult {
+pub(crate) fn user_create(context: &mut ConsoleContext, input: &[String])-> CommandResult {
     let driver = context.driver.clone();
     let username = input[0].clone();
     let password = input[1].clone();
@@ -67,7 +68,7 @@ pub(crate) fn user_create(context: &mut ConsoleContext, input: &[String]) -> Rep
     Ok(())
 }
 
-pub(crate) fn user_delete(context: &mut ConsoleContext, input: &[String]) -> ReplResult {
+pub(crate) fn user_delete(context: &mut ConsoleContext, input: &[String])-> CommandResult {
     let driver = context.driver.clone();
     let username = input[0].clone();
     context.background_runtime.run(async move {
@@ -86,7 +87,7 @@ pub(crate) fn user_delete(context: &mut ConsoleContext, input: &[String]) -> Rep
     Ok(())
 }
 
-pub(crate) fn user_update_password(context: &mut ConsoleContext, input: &[String]) -> ReplResult {
+pub(crate) fn user_update_password(context: &mut ConsoleContext, input: &[String])-> CommandResult {
     let driver = context.driver.clone();
     let username = input[0].clone();
     let new_password = input[1].clone();
@@ -118,7 +119,7 @@ pub(crate) fn user_update_password(context: &mut ConsoleContext, input: &[String
     Ok(())
 }
 
-pub(crate) fn transaction_read(context: &mut ConsoleContext, input: &[String]) -> ReplResult {
+pub(crate) fn transaction_read(context: &mut ConsoleContext, input: &[String])-> CommandResult {
     let driver = context.driver.clone();
     let db_name = &input[0];
     let db_name_owned = db_name.clone();
@@ -132,7 +133,7 @@ pub(crate) fn transaction_read(context: &mut ConsoleContext, input: &[String]) -
     Ok(())
 }
 
-pub(crate) fn transaction_write(context: &mut ConsoleContext, input: &[String]) -> ReplResult {
+pub(crate) fn transaction_write(context: &mut ConsoleContext, input: &[String])-> CommandResult {
     let driver = context.driver.clone();
     let db_name = &input[0];
     let db_name_owned = db_name.clone();
@@ -146,7 +147,7 @@ pub(crate) fn transaction_write(context: &mut ConsoleContext, input: &[String]) 
     Ok(())
 }
 
-pub(crate) fn transaction_schema(context: &mut ConsoleContext, input: &[String]) -> ReplResult {
+pub(crate) fn transaction_schema(context: &mut ConsoleContext, input: &[String])-> CommandResult {
     let driver = context.driver.clone();
     let db_name = &input[0];
     let db_name_owned = db_name.clone();
@@ -160,7 +161,7 @@ pub(crate) fn transaction_schema(context: &mut ConsoleContext, input: &[String])
     Ok(())
 }
 
-pub(crate) fn transaction_commit(context: &mut ConsoleContext, _input: &[String]) -> ReplResult {
+pub(crate) fn transaction_commit(context: &mut ConsoleContext, _input: &[String])-> CommandResult {
     match context.background_runtime.run(context.transaction.take().unwrap().commit()) {
         Ok(_) => {
             println!("Successfully committed transaction.");
@@ -174,7 +175,7 @@ pub(crate) fn transaction_commit(context: &mut ConsoleContext, _input: &[String]
     }
 }
 
-pub(crate) fn transaction_close(context: &mut ConsoleContext, _input: &[String]) -> ReplResult {
+pub(crate) fn transaction_close(context: &mut ConsoleContext, _input: &[String])-> CommandResult {
     let transaction = context.transaction.take().unwrap(); // drop
     let message = match transaction.type_() {
         TransactionType::Read => "Transaction closed",
@@ -185,7 +186,7 @@ pub(crate) fn transaction_close(context: &mut ConsoleContext, _input: &[String])
     Ok(())
 }
 
-pub(crate) fn transaction_rollback(context: &mut ConsoleContext, _input: &[String]) -> ReplResult {
+pub(crate) fn transaction_rollback(context: &mut ConsoleContext, _input: &[String])-> CommandResult {
     let transaction = context.transaction.take().unwrap();
     let (transaction, result) = context.background_runtime.run(async move {
         let result = transaction.rollback().await;
@@ -205,7 +206,7 @@ pub(crate) fn transaction_rollback(context: &mut ConsoleContext, _input: &[Strin
     }
 }
 
-pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String]) -> ReplResult {
+pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])-> CommandResult {
     let file_str = &input[0];
     let path = Path::new(file_str);
     if !path.exists() {
@@ -257,7 +258,7 @@ pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])
     Ok(())
 }
 
-pub(crate) fn transaction_query(context: &mut ConsoleContext, input: &[impl AsRef<str>]) -> ReplResult {
+pub(crate) fn transaction_query(context: &mut ConsoleContext, input: &[impl AsRef<str>])-> CommandResult {
     let query = input[0].as_ref().to_owned();
     execute_query(context, query, true).map_err(|err| Box::new(err) as Box<dyn Error + Send>)
 }

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -12,46 +12,152 @@ use std::{
     rc::Rc,
 };
 
-use rustyline::{
-    completion::{extract_word, Completer},
-    highlight::Highlighter,
-    hint::Hinter,
-};
+use rustyline::{completion::{Completer, extract_word}, highlight::Highlighter, hint::Hinter};
 
-use crate::repl::{line_reader::LineReaderHidden, ReplResult};
+use crate::repl::{line_reader::LineReaderHidden, ReplContext};
 
 pub(crate) trait Command<Context> {
-    // single-word token
-    fn token(&self) -> &'static str;
+    fn token(&self) -> &CommandToken;
 
     // recursively try to complete either this command, or any subcommand, based on the input
     // where the input was already matched against & excludes any parent commands
     fn compute_completions(&self, input: &str) -> Vec<String>;
 
-    fn is_complete_command(&self, input: &str) -> bool;
+    fn match_<'a>(&self, input: &'a str) -> Result<Option<(&dyn ExecutableCommand<Context>, &'a str, usize)>, Box<dyn Error + Send>>;
 
-    // execute this command with the provided input
-    fn execute(&self, context: &mut Context, input: &str) -> ReplResult;
-
-    fn usage_description(&self) -> Box<dyn Iterator<Item = (String, &'static str)> + '_>;
+    fn usage_description(&self) -> Box<dyn Iterator<Item=(String, &'static str)> + '_>;
 }
 
-pub(crate) type CommandExecutor<Context> = fn(&mut Context, &[String]) -> ReplResult;
+pub(crate) trait ExecutableCommand<Context>: Command<Context> {
+    // execute this command with the provided input
+    fn execute(&self, context: &mut Context, args: &str) -> CommandResult;
+}
 
-pub(crate) struct CommandOption<Context> {
-    token: &'static str,
+pub(crate) type CommandExecutor<Context> = fn(&mut Context, &[String]) -> CommandResult;
+pub(crate) type CommandResult = Result<(), Box<dyn Error + Send>>;
+
+pub(crate) struct Subcommand<Context> {
+    token: CommandToken,
+    subcommands: Vec<Rc<dyn Command<Context>>>, // TODO: use a datastructure that sorts by token length in decreasing size
+    default: Option<Rc<CommandDefault<Context>>>,
+}
+
+impl<Context> Subcommand<Context> {
+    pub(crate) fn new(token: impl Into<CommandToken>) -> Self {
+        Self { token: token.into(), subcommands: Vec::new(), default: None }
+    }
+
+    pub(crate) fn add(mut self, command: impl Command<Context> + 'static) -> Self {
+        assert!(!command.token().token.is_empty());
+        if self.subcommands.iter().any(|cmd| cmd.token() == command.token()) {
+            panic!("Duplicate subcommands with token: {}", command.token());
+        }
+        self.subcommands.push(Rc::new(command));
+        self
+    }
+
+    pub(crate) fn add_default(mut self, command: CommandDefault<Context>) -> Self {
+        self.default = Some(Rc::new(command));
+        self
+    }
+}
+
+impl<Context: ReplContext> Command<Context> for Subcommand<Context> {
+    fn token(&self) -> &CommandToken {
+        &self.token
+    }
+
+    fn compute_completions(&self, input: &str) -> Vec<String> {
+        if input.ends_with(char::is_whitespace) {
+            return Vec::with_capacity(0);
+        }
+        if let Some((_, remaining, _)) = self.token.match_(input) {
+            if remaining.starts_with(char::is_whitespace) || remaining == input {
+                self.subcommands.iter().flat_map(|cmd| cmd.compute_completions(remaining.trim_start()))
+                    .chain(self.default.as_ref().iter().flat_map(|default| default.compute_completions(remaining.trim_start()).into_iter()))
+                    .collect()
+            } else {
+                Vec::with_capacity(0)
+            }
+        } else if self.token.completes(input) {
+            vec![self.token.token.to_owned()]
+        } else {
+            Vec::with_capacity(0)
+        }
+    }
+
+    fn match_<'a>(&self, input: &'a str) -> Result<Option<(&dyn ExecutableCommand<Context>, &'a str, usize)>, Box<dyn Error + Send>> {
+        log(&format!("Checking matches for input: {}\n", input));
+        match self.token.match_(input) {
+            None => Ok(None),
+            Some((_token, remaining, token_end_index)) => {
+                log(&format!("Matched subcommand: '{}', remainder: '{}', remainder_start_index: {}\n", _token, remaining, token_end_index));
+                for subcommand in &self.subcommands {
+                    match subcommand.match_(remaining)? {
+                        None => continue,
+                        Some((command, remaining_after_subcommand, command_end_index)) => {
+                            log(&format!(
+                                "From: '{}', Matched subcommand: '{}', remaining: '{}', command_end_index: '{}'\n",
+                                remaining, command.token(), remaining_after_subcommand, command_end_index
+                            ));
+                            // since we only reveal the substring to the subcommand, we need to extend the index by whatever we removed from the start
+                            return Ok(Some((command, remaining_after_subcommand, token_end_index + command_end_index)));
+                        }
+                    }
+                }
+                match self.default.as_ref() {
+                    None => {
+                        Err(Box::new(ReplError { message:
+                            format!("Unrecognised '{}' subcommand: '{}', please type 'help' to see the help menu.", self.token, remaining.trim())
+                        }))
+                    }
+                    Some(default) => {
+                        default.match_(input)
+                    }
+                }
+            }
+        }
+    }
+
+    fn usage_description(&self) -> Box<dyn Iterator<Item=(String, &'static str)> + '_> {
+        Box::new(
+            self.subcommands
+                .iter()
+                .rev()
+                .flat_map(|command| {
+                    command.usage_description().map(|(usage, description)| {
+                        if self.token().token.is_empty() {
+                            (usage, description)
+                        } else {
+                            (format!("{} {}", self.token, usage), description)
+                        }
+                    })
+                })
+                .chain(self.default.iter().flat_map(|default| default.usage_description())),
+        )
+    }
+}
+
+impl<Context> Clone for Subcommand<Context> {
+    fn clone(&self) -> Self {
+        Self { token: self.token, subcommands: self.subcommands.clone(), default: self.default.clone() }
+    }
+}
+
+pub(crate) struct CommandLeaf<Context> {
+    token: CommandToken,
     description: &'static str,
     arguments: Vec<CommandInput>,
     executor: CommandExecutor<Context>,
 }
 
-impl<Context> CommandOption<Context> {
-    pub(crate) fn new(token: &'static str, description: &'static str, executor: CommandExecutor<Context>) -> Self {
+impl<Context> CommandLeaf<Context> {
+    pub(crate) fn new(token: impl Into<CommandToken>, description: &'static str, executor: CommandExecutor<Context>) -> Self {
         Self::new_with_inputs(token, description, vec![], executor)
     }
 
     pub(crate) fn new_with_input(
-        token: &'static str,
+        token: impl Into<CommandToken>,
         description: &'static str,
         arguments: CommandInput,
         executor: CommandExecutor<Context>,
@@ -60,32 +166,27 @@ impl<Context> CommandOption<Context> {
     }
 
     pub(crate) fn new_with_inputs(
-        token: &'static str,
+        token: impl Into<CommandToken>,
         description: &'static str,
         arguments: Vec<CommandInput>,
         executor: CommandExecutor<Context>,
     ) -> Self {
-        Self { token, description, arguments, executor }
+        Self { token: token.into(), description, arguments, executor }
     }
 }
 
-impl<Context> Command<Context> for CommandOption<Context> {
-    fn token(&self) -> &'static str {
-        self.token
+impl<Context: ReplContext> Command<Context> for CommandLeaf<Context> {
+    fn token(&self) -> &CommandToken {
+        &self.token
     }
 
     fn compute_completions(&self, input: &str) -> Vec<String> {
         if input.ends_with(char::is_whitespace) {
             return Vec::with_capacity(0);
         }
-        let mut inputs = input.trim_start().split_whitespace();
-        let command = match inputs.next() {
-            None => return Vec::with_capacity(0),
-            Some(command) => command,
-        };
-        let remaining = input.trim_start().strip_prefix(command).unwrap();
-        if self.token == command {
-            match inputs.enumerate().last() {
+        if let Some((_, remaining, _)) = self.token.match_(input) {
+            let args = remaining.trim_start().split_whitespace();
+            match args.enumerate().last() {
                 None => {
                     // no more inputs are available
                     Vec::with_capacity(0)
@@ -98,47 +199,25 @@ impl<Context> Command<Context> for CommandOption<Context> {
                     }
                 }
             }
-        } else if self.token.starts_with(command) && remaining.trim().is_empty() {
-            vec![self.token.to_owned()]
+        } else if self.token.completes(input) {
+            vec![self.token.token.to_owned()]
         } else {
             Vec::with_capacity(0)
         }
     }
 
-    fn is_complete_command(&self, input: &str) -> bool {
-        let mut inputs = input.trim_start().split_whitespace().peekable();
-        let command = match inputs.next() {
-            None => return false,
-            Some(command) => command,
-        };
-        self.token == command
+    fn match_<'a>(&self, input: &'a str) -> Result<Option<(&dyn ExecutableCommand<Context>, &'a str, usize)>, Box<dyn Error + Send>> {
+        log(&format!("checking command leaf: {}\n", self.token));
+        Ok(self.token.match_(input)
+            .map(|(_token, remaining, token_end_index)| {
+                log(&format!("--> matched leaf: {} with remainder: '{}', and token end index: {}\n", self.token, remaining, token_end_index));
+                // split to the end of the line
+                let args_end = remaining.find("\n").unwrap_or_else(|| remaining.len());
+                (self as &dyn ExecutableCommand<Context>, &remaining[0..args_end], token_end_index + args_end)
+            }))
     }
 
-    fn execute<'a>(&'a self, context: &mut Context, mut input: &'a str) -> ReplResult {
-        let mut arguments: Vec<String> = Vec::new();
-        for (index, argument) in self.arguments.iter().enumerate() {
-            let (arg_value, remaining_input) = match argument.get(input) {
-                None => {
-                    if argument.is_hidden() {
-                        (argument.get_as_hidden().unwrap(), input)
-                    } else {
-                        return Err(Box::new(ReplError {
-                            message: format!("Missing argument {}: {}", index + 1, argument.usage),
-                        }));
-                    }
-                }
-                Some((arg_value, remaining_input)) => (arg_value.to_owned(), remaining_input),
-            };
-            arguments.push(arg_value);
-            input = remaining_input;
-        }
-        if !input.trim().is_empty() {
-            return Err(Box::new(ReplError { message: format!("Unexpected extra arguments: {}", input) }));
-        }
-        (self.executor)(context, &arguments)
-    }
-
-    fn usage_description(&self) -> Box<dyn Iterator<Item = (String, &'static str)> + '_> {
+    fn usage_description(&self) -> Box<dyn Iterator<Item=(String, &'static str)> + '_> {
         let mut usage = format!("{}", self.token);
         for arg in &self.arguments {
             usage = format!("{} <{}>", usage, arg.usage());
@@ -147,8 +226,36 @@ impl<Context> Command<Context> for CommandOption<Context> {
     }
 }
 
-pub(crate) type InputReaderFn = for<'a> fn(&'a str) -> Option<(&'a str, &'a str)>;
-pub(crate) type HiddenReaderFn = for<'a> fn(&'a str) -> Option<(&'a str, &'a str)>;
+impl<Context: ReplContext> ExecutableCommand<Context> for CommandLeaf<Context> {
+    fn execute(&self, context: &mut Context, mut args: &str) -> CommandResult {
+        let mut parsed_args: Vec<String> = Vec::new();
+        for (index, argument) in self.arguments.iter().enumerate() {
+            let (arg_value, remaining_input) = match argument.read_end_index_from(args) {
+                Some(end_index) => {
+                    (args[0..end_index].trim().to_owned(), &args[end_index..])
+                }
+                None => {
+                    if argument.is_hidden() {
+                        (argument.request_hidden()?, args)
+                    } else {
+                        return Err(Box::new(ReplError {
+                            message: format!("Missing argument {}: {}", index + 1, argument.usage),
+                        }));
+                    }
+                }
+            };
+            parsed_args.push(arg_value);
+            args = remaining_input;
+        }
+        if !args.trim().is_empty() {
+            return Err(Box::new(ReplError { message: format!("Unexpected extra arguments: {}", args) }));
+        }
+        log(&format!("Executing '{}' with arguments {:?}\n", self.token, parsed_args));
+        (self.executor)(context, &parsed_args)
+    }
+}
+
+pub(crate) type InputReaderFn = for<'a> fn(&'a str) -> Option<usize>;
 // since we can't pass the context in through RustyLine's completion/hinting system, we have to hack around it
 // this type lets us construct a closure capturing whatever we want
 pub(crate) type InputCompleterFn = dyn for<'a> Fn(&'a str) -> Vec<String>;
@@ -156,7 +263,7 @@ pub(crate) type InputCompleterFn = dyn for<'a> Fn(&'a str) -> Vec<String>;
 pub(crate) struct CommandInput {
     usage: &'static str,
     reader: InputReaderFn,
-    hidden_reader: Option<HiddenReaderFn>,
+    hidden_reader: Option<InputReaderFn>,
     completer: Option<Box<InputCompleterFn>>,
 }
 
@@ -164,13 +271,13 @@ impl CommandInput {
     pub(crate) fn new(
         usage: &'static str,
         reader: InputReaderFn,
-        hidden_reader: Option<HiddenReaderFn>,
+        hidden_reader: Option<InputReaderFn>,
         completer: Option<Box<InputCompleterFn>>,
     ) -> Self {
         Self { usage, reader, hidden_reader, completer }
     }
 
-    fn get<'a>(&self, input: &'a str) -> Option<(&'a str, &'a str)> {
+    fn read_end_index_from<'a>(&self, input: &'a str) -> Option<usize> {
         (self.reader)(input)
     }
 
@@ -178,15 +285,29 @@ impl CommandInput {
         self.hidden_reader.is_some()
     }
 
-    fn get_as_hidden(&self) -> Result<String, ReplError> {
-        Ok(LineReaderHidden::new().readline(&format!("{}: ", self.usage)))
+    fn request_hidden(&self) -> Result<String, Box<dyn Error + Send>> {
+        match self.hidden_reader.as_ref() {
+            Some(reader) => {
+                let string = LineReaderHidden::new().readline(&format!("{}: ", self.usage));
+                let input_end = match reader(&string) {
+                    None => return Err(Box::new(ReplError { message: format!("Could not read input for '{}'", self.usage) })),
+                    Some(end) => end,
+                };
+                Ok(string[0..input_end].to_owned())
+            }
+            None => {
+                Err(Box::new(ReplError {
+                    message: format!("{} cannot be requested as a hidden parameter and must be entered as part of the command.", self.usage)
+                }))
+            }
+        }
     }
 
     // Return completions that are longer than the input
     fn completions(&self, input: &str) -> Vec<String> {
-        let input = match self.get(input) {
+        let input = match self.read_end_index_from(input) {
             None => return Vec::with_capacity(0),
-            Some((input, _)) => input,
+            Some(index) => &input[0..index],
         };
         match &self.completer {
             None => Vec::with_capacity(0),
@@ -203,40 +324,24 @@ impl CommandInput {
     }
 }
 
-pub(crate) fn get_word(input: &str) -> Option<(&str, &str)> {
+pub(crate) fn get_word(input: &str) -> Option<usize> {
     if input.is_empty() {
         None
     } else {
-        Some(input.trim_start().split_once(char::is_whitespace).unwrap_or((input, "")))
+        match input.trim_start().find(char::is_whitespace) {
+            None => Some(input.len()),
+            Some(pos) => Some(pos)
+        }
     }
 }
 
-pub(crate) fn get_multiline_query(input: &str) -> Option<(&str, &str)> {
-    let mut previous_newline: usize = 0;
-    while let Some(newline_pos) = input.find("\n") {
-        // let before = &input[0..newline_pos];
-        // let after = &input[newline_pos..];
-        let line_before = &input[previous_newline..newline_pos];
-        if line_before.trim().is_empty() {
-            return (current_query_range
-        }
-
-    }
-
-
-    let mut lines = input.lines();
-    let last_line = match lines.next() {
-        None => return None,
-        Some(line) => line,
-    };
-    if last_line.trim().is_empty() {
-
-    }
-
-    Some((input, ""))
+pub(crate) fn get_until_empty_line(input: &str) -> Option<usize> {
+    // TODO: enhance to allow newlines with whitespace characters included
+    input.find("\n\n")
 }
 
 pub(crate) struct CommandDefault<Context> {
+    token: CommandToken,
     description: &'static str,
     reader: CommandInput,
     executor: CommandExecutor<Context>,
@@ -244,160 +349,93 @@ pub(crate) struct CommandDefault<Context> {
 
 impl<Context> CommandDefault<Context> {
     pub(crate) fn new(description: &'static str, reader: CommandInput, executor: CommandExecutor<Context>) -> Self {
-        Self { description, reader, executor }
-    }
-
-    fn execute(&self, context: &mut Context, input: &str) -> ReplResult {
-        let (argument, remainder) = match self.reader.get(input) {
-            None => {
-                if self.reader.is_hidden() {
-                    (self.reader.get_as_hidden().unwrap(), input)
-                } else {
-                    return Err(Box::new(ReplError {
-                        message: format!("'{}' could not parse from input: {}", self.reader.usage(), input),
-                    }));
-                }
-            }
-            Some((argument, remainder)) => (argument.to_owned(), remainder),
-        };
-        if !remainder.trim().is_empty() {
-            return Err(Box::new(ReplError {
-                message: format!("Unexpected extra inputs for {}: {}", self.description, remainder),
-            }));
-        }
-        (self.executor)(context, &[argument])
-    }
-
-    fn is_complete_command(&self, input: &str) -> bool {
-        self.reader.get(input)
-    }
-
-    fn usage_description(&self) -> (String, &'static str) {
-        ("*".to_owned(), self.description)
+        Self { token: CommandToken::new(""), description, reader, executor }
     }
 }
 
-pub(crate) struct Subcommands<Context> {
-    token: &'static str,
-    subcommands: Vec<Rc<dyn Command<Context>>>,
-    default: Option<Rc<CommandDefault<Context>>>,
-}
-
-impl<Context> Subcommands<Context> {
-    pub(crate) fn new(token: &'static str) -> Self {
-        Self { token, subcommands: Vec::new(), default: None }
-    }
-
-    pub(crate) fn add(mut self, command: impl Command<Context> + 'static) -> Self {
-        if self.subcommands.iter().any(|cmd| cmd.token() == command.token()) {
-            panic!("Duplicate subcommands with token: {}", command.token());
-        }
-        self.subcommands.push(Rc::new(command));
-        self
-    }
-
-    pub(crate) fn add_default(mut self, command: CommandDefault<Context>) -> Self {
-        self.default = Some(Rc::new(command));
-        self
-    }
-}
-
-impl<Context> Command<Context> for Subcommands<Context> {
-    fn token(&self) -> &'static str {
-        self.token
+impl<Context: ReplContext> Command<Context> for CommandDefault<Context> {
+    fn token(&self) -> &CommandToken {
+        &self.token
     }
 
     fn compute_completions(&self, input: &str) -> Vec<String> {
-        if input.ends_with(char::is_whitespace) {
-            return Vec::with_capacity(0);
-        }
-        if self.token.is_empty() {
-            return self.subcommands.iter().flat_map(|cmd| cmd.compute_completions(input)).collect();
-        }
-
-        let command = input.trim_start().split_whitespace().next().unwrap();
-        let remaining_input = input.trim_start().strip_prefix(command).unwrap();
-        if self.token == command {
-            if remaining_input.starts_with(char::is_whitespace) {
-                self.subcommands.iter().flat_map(|cmd| cmd.compute_completions(remaining_input.trim_start())).collect()
-            } else {
-                Vec::with_capacity(0)
-            }
-        } else if self.token.starts_with(command) && remaining_input.trim().is_empty() {
-            vec![self.token.to_owned()]
-        } else {
-            Vec::with_capacity(0)
-        }
+        Vec::with_capacity(0)
     }
 
-    fn is_complete_command(&self, input: &str) -> bool {
-        if self.token.is_empty() {
-            return self.subcommands.iter().any(|cmd| cmd.is_complete_command(input));
-        }
-
-        let command = input.trim_start().split_whitespace().next().unwrap();
-        if self.token == command {
-            let remaining_input = input.trim_start().strip_prefix(command).unwrap();
-            if remaining_input.starts_with(char::is_whitespace) {
-                self.subcommands.iter().any(|cmd| cmd.is_complete_command(remaining_input.trim_start()))
-            } else {
-                false
-            }
-        } else if let Some(default) = self.default.as_ref() {
-            default.is_complete_command(input)
-        } else {
-            false
-        }
-    }
-
-    fn execute(&self, context: &mut Context, input: &str) -> ReplResult {
-        let (command, remainder) = match get_word(input) {
-            None => {
-                return Err(Box::new(ReplError {
-                    message: format!(
-                        "Failed to read {} command from input {}, please type 'help' to see the help menu.",
-                        self.token, input
-                    ),
-                }));
-            }
-            Some((command, remainder)) => (command.trim(), remainder),
-        };
-        for subcommand in &self.subcommands {
-            if command == subcommand.token() {
-                return subcommand.execute(context, remainder.trim_start());
-            }
-        }
-        if let Some(default) = &self.default {
-            default.execute(context, input)
-        } else {
-            Err(Box::new(ReplError {
-                message: format!("Unrecognised command: {}, please type 'help' to see the help menu.", input),
+    fn match_<'a>(&self, input: &'a str) -> Result<Option<(&dyn ExecutableCommand<Context>, &'a str, usize)>, Box<dyn Error + Send>> {
+        // self.reader.get(input).is_some()
+        Ok(self.reader.read_end_index_from(input)
+            .map(|input_end_index| {
+                log(&format!("--> matched default: {}\n", self.description));
+                (self as &dyn ExecutableCommand<Context>, &input[0..input_end_index], input_end_index)
             }))
-        }
     }
 
-    fn usage_description(&self) -> Box<dyn Iterator<Item = (String, &'static str)> + '_> {
-        Box::new(
-            self.subcommands
-                .iter()
-                .rev()
-                .flat_map(|command| {
-                    command.usage_description().map(|(usage, description)| {
-                        if self.token().is_empty() {
-                            (usage, description)
-                        } else {
-                            (format!("{} {}", self.token, usage), description)
-                        }
-                    })
-                })
-                .chain(self.default.iter().map(|default| default.usage_description())),
-        )
+    fn usage_description(&self) -> Box<dyn Iterator<Item=(String, &'static str)> + '_> {
+        Box::new([("*".to_owned(), self.description)].into_iter())
     }
 }
 
-impl<Context> Clone for Subcommands<Context> {
-    fn clone(&self) -> Self {
-        Self { token: self.token, subcommands: self.subcommands.clone(), default: self.default.clone() }
+impl<Context: ReplContext> ExecutableCommand<Context> for CommandDefault<Context> {
+    fn execute(&self, context: &mut Context, args: &str) -> CommandResult {
+        (self.executor)(context, &[args.to_owned()])
+    }
+}
+
+pub fn log(string: &str) {
+    match std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open("output")
+        .and_then(|mut file| std::io::Write::write_all(&mut file, string.as_bytes()))
+    {
+        Ok(_) => {}
+        Err(_) => {}
+    };
+}
+
+fn whitespace_without_newline(c: char) -> bool {
+    c.is_whitespace() && c != '\n'
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CommandToken {
+    token: &'static str,
+}
+
+impl CommandToken {
+    fn new(token: &'static str) -> Self {
+        Self { token }
+    }
+
+    fn match_<'a>(&self, input: &'a str) -> Option<(&'a str, &'a str, usize)> {
+        match input.find(self.token) {
+            None => None,
+            Some(pos) => {
+                if (&input[0..pos]).trim_matches(whitespace_without_newline).is_empty() {
+                    let end = pos + self.token.len();
+                    Some((&input[0..end], &input[end..], end))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn completes(&self, input: &str) -> bool {
+        self.token.starts_with(input.trim())
+    }
+}
+
+impl Into<CommandToken> for &'static str {
+    fn into(self) -> CommandToken {
+        CommandToken::new(self)
+    }
+}
+
+impl Display for CommandToken {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.token)
     }
 }
 
@@ -405,13 +443,13 @@ pub(crate) trait CommandDefinitions: Highlighter + Hinter + Completer {
     fn is_complete_command(&self, input: &str) -> bool;
 }
 
-impl<Context> CommandDefinitions for Subcommands<Context> {
+impl<Context: ReplContext> CommandDefinitions for Subcommand<Context> {
     fn is_complete_command(&self, input: &str) -> bool {
-        Command::is_complete_command(self, input)
+        matches!(Command::match_(self, input), Ok(Some(_)))
     }
 }
 
-impl<Context> Completer for Subcommands<Context> {
+impl<Context: ReplContext> Completer for Subcommand<Context> {
     type Candidate = String;
 
     fn complete(
@@ -429,7 +467,7 @@ impl<Context> Completer for Subcommands<Context> {
     }
 }
 
-impl<Context> Hinter for Subcommands<Context> {
+impl<Context: ReplContext> Hinter for Subcommand<Context> {
     type Hint = String;
 
     fn hint(&self, line: &str, pos: usize, _ctx: &rustyline::Context<'_>) -> Option<Self::Hint> {
@@ -446,7 +484,7 @@ impl<Context> Hinter for Subcommands<Context> {
     }
 }
 
-impl<Context> Highlighter for Subcommands<Context> {
+impl<Context: ReplContext> Highlighter for Subcommand<Context> {
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
         Cow::Owned(format!("\x1b[37m{}\x1b[0m", hint))
     }

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -448,13 +448,18 @@ impl<Context: ReplContext> Hinter for Subcommand<Context> {
     type Hint = String;
 
     fn hint(&self, line: &str, pos: usize, _ctx: &rustyline::Context<'_>) -> Option<Self::Hint> {
+        log(&format!("1 Looking for candidates for: '{}'\n", line));
         let (_, candidates) = self.complete(line, pos, _ctx).ok()?;
         let (_, last_word) = extract_word(line, pos, None, char::is_whitespace);
 
         if candidates.len() == 1 {
+            log(&format!("1 Candidate found: '{}'. Last word in line: '{}'\n", &candidates[0], last_word));
             let candidate = candidates.into_iter().next().unwrap();
-            let hint = candidate[last_word.len()..].to_owned();
-            Some(hint)
+            if candidate.len() < last_word.len() {
+                None
+            } else {
+                Some(candidate[last_word.len()..].to_owned())
+            }
         } else {
             None
         }

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -275,7 +275,7 @@ impl<Context: ReplContext> Command<Context> for CommandLeaf<Context> {
 }
 
 impl<Context: ReplContext> ExecutableCommand<Context> for CommandLeaf<Context> {
-    fn execute(&self, context: &mut Context, mut args: Vec<String>) -> CommandResult {
+    fn execute(&self, context: &mut Context, args: Vec<String>) -> CommandResult {
         (self.executor)(context, &args)
     }
 }

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -366,13 +366,25 @@ pub(crate) fn get_word(input: &str, _coerce_to_one_line: bool) -> Option<usize> 
     }
 }
 
-pub(crate) fn get_or_until_empty_line(input: &str, coerce_to_one_line: bool) -> Option<usize> {
+pub(crate) fn get_to_empty_line(mut input: &str, coerce_to_one_line: bool) -> Option<usize> {
     if coerce_to_one_line {
         Some(input.len())
     } else {
-        // TODO: enhance to allow newlines with whitespace characters included
-        const PATTERN: &str = "\n\n";
-        input.find(PATTERN).map(|pos| pos + PATTERN.len())
+        const PATTERN: &str = "\n";
+        let mut pos = 0;
+        while let Some(newline_pos) = input.find(PATTERN) {
+            let next_newline_pos = match input[newline_pos + 1..].find(PATTERN) {
+                None => return None,
+                Some(next_newline_pos) => newline_pos + 1 + next_newline_pos,
+            };
+            pos += newline_pos;
+            if input[newline_pos..next_newline_pos].trim().is_empty() {
+                return Some(pos);
+            }
+            input = &input[newline_pos + 1..];
+            pos += 1;
+        }
+        None
     }
 }
 

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -211,7 +211,28 @@ pub(crate) fn get_word(input: &str) -> Option<(&str, &str)> {
     }
 }
 
-pub(crate) fn get_all(input: &str) -> Option<(&str, &str)> {
+pub(crate) fn get_multiline_query(input: &str) -> Option<(&str, &str)> {
+    let mut previous_newline: usize = 0;
+    while let Some(newline_pos) = input.find("\n") {
+        // let before = &input[0..newline_pos];
+        // let after = &input[newline_pos..];
+        let line_before = &input[previous_newline..newline_pos];
+        if line_before.trim().is_empty() {
+            return (current_query_range
+        }
+
+    }
+
+
+    let mut lines = input.lines();
+    let last_line = match lines.next() {
+        None => return None,
+        Some(line) => line,
+    };
+    if last_line.trim().is_empty() {
+
+    }
+
     Some((input, ""))
 }
 
@@ -245,6 +266,10 @@ impl<Context> CommandDefault<Context> {
             }));
         }
         (self.executor)(context, &[argument])
+    }
+
+    fn is_complete_command(&self, input: &str) -> bool {
+        self.reader.get(input)
     }
 
     fn usage_description(&self) -> (String, &'static str) {
@@ -318,6 +343,8 @@ impl<Context> Command<Context> for Subcommands<Context> {
             } else {
                 false
             }
+        } else if let Some(default) = self.default.as_ref() {
+            default.is_complete_command(input)
         } else {
             false
         }

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -355,7 +355,7 @@ impl CommandInput {
 }
 
 pub(crate) fn get_word(input: &str, _coerce_to_one_line: bool) -> Option<usize> {
-    if input.is_empty() {
+    if input.trim().is_empty() {
         None
     } else {
         let after_starting_whitespace = input.find(|c: char| !c.is_whitespace()).unwrap_or(0);

--- a/src/repl/line_reader.rs
+++ b/src/repl/line_reader.rs
@@ -29,7 +29,7 @@ pub(crate) struct RustylineReader<H: Helper> {
 
 impl<H: CommandDefinitions> RustylineReader<EditorHelper<H>> {
     pub(crate) fn new(command_helper: H, history_file: PathBuf, multiline: bool) -> Self {
-        let mut config = Config::builder().completion_type(CompletionType::Circular).build();
+        let config = Config::builder().completion_type(CompletionType::Circular).build();
         let history = FileHistory::new();
 
         let mut editor = Editor::with_history(config, history).unwrap(); // TODO unwrap
@@ -140,7 +140,7 @@ struct SearchHistoryModeReset {
 }
 
 impl ConditionalEventHandler for SearchHistoryModeReset {
-    fn handle(&self, evt: &Event, _n: RepeatCount, _positive: bool, ctx: &rustyline::EventContext) -> Option<Cmd> {
+    fn handle(&self, evt: &Event, _n: RepeatCount, _positive: bool, _ctx: &rustyline::EventContext) -> Option<Cmd> {
         if let Event::KeySeq(keys) = evt {
             if !(keys.contains(&KeyEvent(KeyCode::Up, Modifiers::NONE))
                 || keys.contains(&KeyEvent(KeyCode::Down, Modifiers::NONE)))

--- a/src/repl/line_reader.rs
+++ b/src/repl/line_reader.rs
@@ -10,9 +10,15 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use rustyline::{Cmd, completion::Completer, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, Helper, highlight::Highlighter, hint::Hinter, history::FileHistory, KeyCode, KeyEvent, Modifiers,
-                Movement, RepeatCount, validate::{ValidationContext, ValidationResult, Validator}};
-use rustyline::history::History;
+use rustyline::{
+    completion::Completer,
+    highlight::Highlighter,
+    hint::Hinter,
+    history::{FileHistory, History},
+    validate::{ValidationContext, ValidationResult, Validator},
+    Cmd, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, Helper, KeyCode, KeyEvent,
+    Modifiers, Movement, RepeatCount,
+};
 
 use crate::repl::command::CommandDefinitions;
 
@@ -23,9 +29,7 @@ pub(crate) struct RustylineReader<H: Helper> {
 
 impl<H: CommandDefinitions> RustylineReader<EditorHelper<H>> {
     pub(crate) fn new(command_helper: H, history_file: PathBuf, multiline: bool) -> Self {
-        let mut config = Config::builder()
-            .completion_type(CompletionType::Circular)
-            .build();
+        let mut config = Config::builder().completion_type(CompletionType::Circular).build();
         let history = FileHistory::new();
 
         let mut editor = Editor::with_history(config, history).unwrap(); // TODO unwrap

--- a/src/repl/line_reader.rs
+++ b/src/repl/line_reader.rs
@@ -63,7 +63,7 @@ impl<H: CommandDefinitions> RustylineReader<EditorHelper<H>> {
             Ok(line) => {
                 let _ = self.editor.history_mut().add(line.trim_end());
                 let _ = self.editor.append_history(&self.history_file);
-                // Rustyline removes the last newline, which we'll add back
+                // Rustyline removes the last newline - we'll add back so the input matches what one would get from a  file
                 Ok(format!("{}\n", line))
             }
             Err(err) => Err(err),

--- a/src/repl/line_reader.rs
+++ b/src/repl/line_reader.rs
@@ -10,9 +10,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use rustyline::{completion::Completer, highlight::Highlighter, hint::Hinter, history::FileHistory, validate::{ValidationContext, ValidationResult, Validator}, Cmd, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, Helper, KeyCode, KeyEvent,
-    Modifiers, Movement, RepeatCount};
-use rustyline::history::{History, MemHistory};
+use rustyline::{Cmd, completion::Completer, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, Helper, highlight::Highlighter, hint::Hinter, history::FileHistory, KeyCode, KeyEvent, Modifiers,
+                Movement, RepeatCount, validate::{ValidationContext, ValidationResult, Validator}};
+use rustyline::history::History;
 
 use crate::repl::command::CommandDefinitions;
 

--- a/src/repl/line_reader.rs
+++ b/src/repl/line_reader.rs
@@ -10,15 +10,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use rustyline::{
-    completion::Completer,
-    highlight::Highlighter,
-    hint::Hinter,
-    history::FileHistory,
-    validate::{ValidationContext, ValidationResult, Validator},
-    Cmd, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, Helper, KeyCode, KeyEvent,
-    Modifiers, Movement, RepeatCount,
-};
+use rustyline::{completion::Completer, highlight::Highlighter, hint::Hinter, history::FileHistory, validate::{ValidationContext, ValidationResult, Validator}, Cmd, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, Helper, KeyCode, KeyEvent,
+    Modifiers, Movement, RepeatCount, KeyCode};
 use rustyline::history::History;
 
 use crate::repl::command::CommandDefinitions;
@@ -30,8 +23,9 @@ pub(crate) struct RustylineReader<H: Helper> {
 
 impl<H: CommandDefinitions> RustylineReader<EditorHelper<H>> {
     pub(crate) fn new(command_helper: H, history_file: PathBuf, multiline: bool) -> Self {
-        let mut builder = Config::builder().completion_type(CompletionType::Circular);
-        let config = builder.build();
+        let mut config = Config::builder()
+            .completion_type(CompletionType::Circular)
+            .build();
         let history = FileHistory::new();
 
         let mut editor = Editor::with_history(config, history).unwrap(); // TODO unwrap

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -5,16 +5,11 @@
  */
 
 use std::{
-    error::Error,
-    ops::{
-        ControlFlow,
-        ControlFlow::{Break, Continue},
-    },
+    error::Error
+    ,
     path::PathBuf,
     process::exit,
 };
-
-use rustyline::error::ReadlineError;
 
 use crate::repl::{
     command::{Command, CommandDefault, CommandLeaf, Subcommand},
@@ -60,11 +55,6 @@ impl<Context: ReplContext + 'static> Repl<Context> {
         self
     }
 
-    pub(crate) fn add_default(mut self, command: CommandDefault<Context>) -> Self {
-        self.commands = self.commands.add_default(command);
-        self
-    }
-
     pub(crate) fn get_input(&self) -> rustyline::Result<String> {
         let mut editor = RustylineReader::new(self.commands.clone(), self.history_file.clone(), self.multiline_input);
         editor.readline(&self.prompt)
@@ -78,7 +68,7 @@ impl<Context: ReplContext + 'static> Repl<Context> {
     //     self.commands.execute_exact(context, line)
     // }
 
-    pub(crate) fn match_command<'a>(&self, input: &'a str) -> Result<Option<(&dyn ExecutableCommand<Context>, &'a str, usize)>, Box<dyn Error + Send>> {
+    pub(crate) fn match_command<'a>(&self, input: &'a str) -> Result<Option<(&dyn ExecutableCommand<Context>, Vec<String>, usize)>, Box<dyn Error + Send>> {
         self.commands.match_(input)
     }
 

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -4,18 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    error::Error
-    ,
-    path::PathBuf,
-    process::exit,
-};
+use std::{error::Error, path::PathBuf, process::exit};
 
 use crate::repl::{
-    command::{Command, CommandDefault, CommandLeaf, Subcommand},
+    command::{Command, CommandLeaf, CommandResult, ExecutableCommand, Subcommand},
     line_reader::RustylineReader,
 };
-use crate::repl::command::{CommandResult, ExecutableCommand};
 
 pub(crate) mod command;
 pub(crate) mod line_reader;
@@ -44,9 +38,11 @@ impl<Context: ReplContext + 'static> Repl<Context> {
         multiline_input: bool,
         on_finish: Option<fn(&mut Context) -> ()>,
     ) -> Self {
-        let subcommands = Subcommand::new("")
-            .add(CommandLeaf::new(Self::EXIT, "Exit", do_exit))
-            .add(CommandLeaf::new(Self::HELP, "Print help menu", help_menu));
+        let subcommands = Subcommand::new("").add(CommandLeaf::new(Self::EXIT, "Exit", do_exit)).add(CommandLeaf::new(
+            Self::HELP,
+            "Print help menu",
+            help_menu,
+        ));
         Self { prompt, commands: subcommands, history_file, multiline_input, on_finish }
     }
 
@@ -68,7 +64,10 @@ impl<Context: ReplContext + 'static> Repl<Context> {
     //     self.commands.execute_exact(context, line)
     // }
 
-    pub(crate) fn match_command<'a>(&self, input: &'a str) -> Result<Option<(&dyn ExecutableCommand<Context>, Vec<String>, usize)>, Box<dyn Error + Send>> {
+    pub(crate) fn match_command<'a>(
+        &self,
+        input: &'a str,
+    ) -> Result<Option<(&dyn ExecutableCommand<Context>, Vec<String>, usize)>, Box<dyn Error + Send>> {
         self.commands.match_(input)
     }
 

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -69,6 +69,7 @@ impl<Context: ReplContext + 'static> Repl<Context> {
         match editor.readline(&self.prompt) {
             Ok(line) => {
                 if !line.trim().is_empty() {
+                    let multiline_input: Vec<_> = line.lines().collect();
                     Continue(self.execute_once(context, &line))
                 } else {
                     Continue(Ok(()))

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -20,8 +20,6 @@ pub(crate) trait ReplContext: Sized {
     fn current_repl(&self) -> &Repl<Self>;
 }
 
-pub(crate) type ReplResult<'a> = Result<Option<&'a str>, Box<dyn Error + Send>>;
-
 pub(crate) struct Repl<Context> {
     prompt: String,
     commands: Subcommand<Context>,
@@ -76,10 +74,6 @@ impl<Context: ReplContext + 'static> Repl<Context> {
             .map(|(usage, description)| format!("{:<width$}{}", usage, description, width = usage_width))
             .collect::<Vec<_>>()
             .join("\n")
-    }
-
-    pub(crate) fn prompt(&self) -> &str {
-        &self.prompt
     }
 
     pub(crate) fn finished(&self, context: &mut Context) {

--- a/tests/assembly/test_assembly.rs
+++ b/tests/assembly/test_assembly.rs
@@ -19,10 +19,10 @@ const TYPEDB_CONSOLE_SUBCOMMAND: &str = "console";
 #[test]
 fn test_console() -> Result<(), Box<dyn Error>> {
     /*
-     NOTE: subprocesses make the logging and debugging from this test difficult
-           the simplest way to bisect issues is to run TypeDB server externally, and remove it from here
-     */
-    
+    NOTE: subprocesses make the logging and debugging from this test difficult
+          the simplest way to bisect issues is to run TypeDB server externally, and remove it from here
+    */
+
     // can't drop server_runner, or it will delete the temp dir
     let (_server_runner, mut server_process) = run_typedb_server();
 

--- a/tests/assembly/test_assembly.rs
+++ b/tests/assembly/test_assembly.rs
@@ -18,6 +18,11 @@ const TYPEDB_CONSOLE_SUBCOMMAND: &str = "console";
 
 #[test]
 fn test_console() -> Result<(), Box<dyn Error>> {
+    /*
+     NOTE: subprocesses make the logging and debugging from this test difficult
+           the simplest way to bisect issues is to run TypeDB server externally, and remove it from here
+     */
+    
     // can't drop server_runner, or it will delete the temp dir
     let (_server_runner, mut server_process) = run_typedb_server();
 


### PR DESCRIPTION
## Usage and product changes

We refactor the Console to allow pasting a "script" into the current REPL. This will be correctly interpreted and executed as a block of separate commands. The inputs must look as they would when using the console interactively:
```
database create tmp
transaction schema tmp
define entity person;

commit
```

With the empty newline, as in regular interactive console, being used to mark the end of the query.

This is particularly useful for pasting fully self-contained examples from TypeDB documentation into the console!

The format of `--file` scripts (now called `--script`) must follow this same format, instead of using `\` to write multiline queries. We will refer to this as the `TypeDB Console Script`, or `Scripted TypeQL` in some contexts. We use `.tqls` for console scripts, instead of the usual `.tql` which contains pure TypeQL.

## Implementation

We simplify the command definitions, and split the execution into two phases: 
1) match the command - including argument parsing
2) execute the command

We broadly try to parse matches using the index into the input, so that we can split off ranges and pass them around to the next command parser. This is particularly for the case because we want to split out multiple commands from a multiline copy-paste.
