### PR TITLE
Improve UX of Ctrl+C and fix bugs in command submission

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use crate::{
         user_delete, user_update_password,
     },
     repl::{
-        command::{get_to_empty_line, get_word, CommandInput, CommandLeaf, Subcommand},
+        command::{index_after_empty_line, get_word, CommandInput, CommandLeaf, Subcommand},
         line_reader::LineReaderHidden,
         Repl, ReplContext,
     },
@@ -336,7 +336,7 @@ fn transaction_repl(database: &str, transaction_type: TransactionType) -> Repl<C
         .add(CommandLeaf::new_with_input(
             "",
             "Execute query string.",
-            CommandInput::new("query", get_to_empty_line, None, None),
+            CommandInput::new("query", index_after_empty_line, None, None),
             transaction_query,
         ));
     repl

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use crate::{
         user_delete, user_update_password,
     },
     repl::{
-        command::{index_after_empty_line, get_word, CommandInput, CommandLeaf, Subcommand},
+        command::{get_word, index_after_empty_line, CommandInput, CommandLeaf, Subcommand},
         line_reader::LineReaderHidden,
         Repl, ReplContext,
     },
@@ -164,7 +164,7 @@ fn execute_interactive(context: &mut ConsoleContext) {
     while !context.repl_stack.is_empty() {
         let repl_index = context.repl_stack.len() - 1;
         let current_repl = context.repl_stack[repl_index].clone();
-        let result = current_repl.get_input();
+        let (result, interrupt_input_empty) = current_repl.get_input();
         match result {
             Ok(input) => {
                 if !input.trim().is_empty() {
@@ -175,11 +175,14 @@ fn execute_interactive(context: &mut ConsoleContext) {
                 }
             }
             Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => {
-                if context.repl_stack.len() == repl_index + 1 {
+                let exit_once = interrupt_input_empty.unwrap_or(true);
+                if exit_once && context.repl_stack.len() == repl_index + 1 {
                     // TODO: extra way to eliminate the current repl...
                     //  ideally, every command would signal with a new Repl or to pop one off, so stack manipulation is these control loops
                     let last = context.repl_stack.pop();
                     last.unwrap().finished(context);
+                } else if !exit_once {
+                    // do nothing
                 } else {
                     // this is unexpected... quit
                     exit(1)

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -14,7 +14,7 @@ use typedb_driver::{
 
 use crate::{
     printer::{print_document, print_row},
-    repl::command::{get_to_empty_line, CommandResult, ReplError},
+    repl::command::{index_after_empty_line, CommandResult, ReplError},
     transaction_repl, ConsoleContext,
 };
 
@@ -222,7 +222,7 @@ pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])
 
     let mut input: &str = &contents;
     let mut query_count = 0;
-    while let Some(query_end_index) = get_to_empty_line(&input, false) {
+    while let Some(query_end_index) = index_after_empty_line(&input, false) {
         let query = &input[0..query_end_index];
         match execute_query(context, query.to_owned(), false) {
             Err(err) => {
@@ -264,7 +264,11 @@ pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])
 
 pub(crate) fn transaction_query(context: &mut ConsoleContext, input: &[impl AsRef<str>]) -> CommandResult {
     let query = input[0].as_ref().to_owned();
-    execute_query(context, query, true).map_err(|err| Box::new(err) as Box<dyn Error + Send>)
+    if query.trim().is_empty() {
+        return Ok(())
+    } else {
+        execute_query(context, query, true).map_err(|err| Box::new(err) as Box<dyn Error + Send>)
+    }
 }
 
 const QUERY_TYPE_TEMPLATE: &'static str = "<QUERY TYPE>";

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -265,7 +265,7 @@ pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])
 pub(crate) fn transaction_query(context: &mut ConsoleContext, input: &[impl AsRef<str>]) -> CommandResult {
     let query = input[0].as_ref().to_owned();
     if query.trim().is_empty() {
-        return Ok(())
+        return Ok(());
     } else {
         execute_query(context, query, true).map_err(|err| Box::new(err) as Box<dyn Error + Send>)
     }

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -114,18 +114,18 @@ impl<Context: ReplContext> Command<Context> for Subcommand<Context> {
     ) -> Result<Option<(&dyn ExecutableCommand<Context>, Vec<String>, usize)>, Box<dyn Error + Send>> {
         match self.token.match_(input) {
             None => Ok(None),
-            Some((_token, remaining, token_end_index)) => {
+            Some((_token, remaining, remaining_start_index)) => {
                 // rev forces longest match first
                 for subcommand in self.subcommands.iter().rev() {
                     match subcommand.match_first(remaining, coerce_to_one_line)? {
                         None => continue,
-                        Some((command, remaining_after_subcommand, command_end_index)) => {
+                        Some((command, remaining_after_subcommand, remaining_after_subcommand_index)) => {
                             // since we only reveal the substring to the subcommand
                             // we need to extend the index by whatever we removed from the start
                             return Ok(Some((
                                 command,
                                 remaining_after_subcommand,
-                                token_end_index + command_end_index,
+                                remaining_start_index + remaining_after_subcommand_index,
                             )));
                         }
                     }
@@ -231,19 +231,15 @@ impl<Context: ReplContext> Command<Context> for CommandLeaf<Context> {
         input: &'a str,
         coerce_to_one_line: bool,
     ) -> Result<Option<(&dyn ExecutableCommand<Context>, Vec<String>, usize)>, Box<dyn Error + Send>> {
+        log(&format!("Trying to match leaf command {} ({}) from input: '{}'", self.token, self.description, input));
         match self.token.match_(input) {
-            Some((_token, mut remaining, token_end_index)) => {
+            Some((_token, mut remaining, mut remaining_start_index)) => {
                 let mut parsed_args: Vec<String> = Vec::new();
-                let mut command_end_index = token_end_index;
                 for (index, argument) in self.arguments.iter().enumerate() {
                     let (arg_value, remaining_input) = match argument.read_end_index_from(remaining, coerce_to_one_line)
                     {
                         Some(end_index) => {
-                            // if accepted 0 inputs, even if it is a match, we should not accept this command
-                            if remaining[0..end_index].is_empty() {
-                                return Ok(None);
-                            }
-                            command_end_index += end_index;
+                            remaining_start_index += end_index;
                             (remaining[0..end_index].trim().to_owned(), &remaining[end_index..])
                         }
                         None => {
@@ -259,7 +255,7 @@ impl<Context: ReplContext> Command<Context> for CommandLeaf<Context> {
                     parsed_args.push(arg_value);
                     remaining = remaining_input;
                 }
-                Ok(Some((self as &dyn ExecutableCommand<Context>, parsed_args, command_end_index)))
+                Ok(Some((self as &dyn ExecutableCommand<Context>, parsed_args, remaining_start_index)))
             }
             None => Ok(None),
         }
@@ -366,23 +362,23 @@ pub(crate) fn get_word(input: &str, _coerce_to_one_line: bool) -> Option<usize> 
     }
 }
 
-pub(crate) fn get_to_empty_line(mut input: &str, coerce_to_one_line: bool) -> Option<usize> {
+pub(crate) fn index_after_empty_line(mut input: &str, coerce_to_one_line: bool) -> Option<usize> {
     if coerce_to_one_line {
         Some(input.len())
     } else {
         const PATTERN: &str = "\n";
         let mut pos = 0;
         while let Some(newline_pos) = input.find(PATTERN) {
-            let next_newline_pos = match input[newline_pos + 1..].find(PATTERN) {
+            let after_newline_pos = newline_pos + 1;
+            let next_newline_pos = match input[after_newline_pos..].find(PATTERN) {
                 None => return None,
-                Some(next_newline_pos) => newline_pos + 1 + next_newline_pos,
+                Some(next_newline_pos) => after_newline_pos + next_newline_pos,
             };
-            pos += newline_pos;
-            if input[newline_pos..next_newline_pos].trim().is_empty() {
-                return Some(pos);
+            pos += after_newline_pos;
+            if input[after_newline_pos..next_newline_pos].trim().is_empty() {
+                return Some(next_newline_pos + 1);
             }
-            input = &input[newline_pos + 1..];
-            pos += 1;
+            input = &input[after_newline_pos..];
         }
         None
     }
@@ -402,8 +398,10 @@ impl CommandToken {
         match input.find(self.token) {
             None => None,
             Some(pos) => {
+                log(&format!("Matched token...'{}' at pos {} ", self.token, pos));
                 if (&input[0..pos]).trim_matches(char::is_whitespace).is_empty() {
                     let end = pos + self.token.len();
+                    log(&format!("...Return matched token! Extracted token: '{}'", &input[0..end]));
                     Some((&input[0..end], &input[end..], end))
                 } else {
                     None
@@ -433,9 +431,42 @@ pub(crate) trait CommandDefinitions: Highlighter + Hinter + Completer {
     fn is_complete_command(&self, input: &str) -> bool;
 }
 
+pub(crate) fn log(input: &str) {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("output.log")
+        .unwrap();
+
+    writeln!(file, "{}", input).unwrap();
+}
+
+
 impl<Context: ReplContext> CommandDefinitions for Subcommand<Context> {
-    fn is_complete_command(&self, input: &str) -> bool {
-        matches!(Command::match_first(self, input, false), Ok(Some(_)))
+    fn is_complete_command(&self, mut input: &str) -> bool {
+        loop {
+            match Command::match_first(self, input, false) {
+                Ok(None) => {
+                    log(&format!("No complete command from input: '{}'", input));
+                    return false
+                },
+                Ok(Some((_executable, _args, end_index))) => {
+                    log(&format!("DID read command from input: '{}'", input));
+                    input = &input[end_index..];
+                    log(&format!("... remaining input is empty: {} : '{}'", input.trim().is_empty(), input));
+                    if input.trim().is_empty() {
+                        return true;
+                    }
+                }
+                Err(err) => {
+                    log(&format!("Parsed ERR: {}", err));
+                    return false
+                },
+            }
+        }
     }
 }
 

--- a/src/repl/line_reader.rs
+++ b/src/repl/line_reader.rs
@@ -17,8 +17,8 @@ use rustyline::{
     hint::Hinter,
     history::{FileHistory, History},
     validate::{ValidationContext, ValidationResult, Validator},
-    Cmd, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, ExternalPrinter, Helper,
-    KeyCode, KeyEvent, Modifiers, RepeatCount,
+    Cmd, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, Helper, KeyCode, KeyEvent,
+    Modifiers, RepeatCount,
 };
 
 use crate::repl::command::CommandDefinitions;
@@ -74,10 +74,6 @@ impl<H: CommandDefinitions> RustylineReader<EditorHelper<H>> {
             }
             Err(err) => (Err(err), None),
         }
-    }
-
-    pub(crate) fn print_external(&mut self, message: String) {
-        self.editor.create_external_printer().unwrap().print(message).unwrap()
     }
 }
 

--- a/src/repl/line_reader.rs
+++ b/src/repl/line_reader.rs
@@ -12,12 +12,13 @@ use std::{
 
 use rustyline::{
     completion::Completer,
+    error::ReadlineError,
     highlight::Highlighter,
     hint::Hinter,
     history::{FileHistory, History},
     validate::{ValidationContext, ValidationResult, Validator},
-    Cmd, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, Helper, KeyCode, KeyEvent,
-    Modifiers, Movement, RepeatCount,
+    Cmd, CompletionType, ConditionalEventHandler, Config, Editor, Event, EventHandler, ExternalPrinter, Helper,
+    KeyCode, KeyEvent, Modifiers, RepeatCount,
 };
 
 use crate::repl::command::CommandDefinitions;
@@ -25,6 +26,8 @@ use crate::repl::command::CommandDefinitions;
 pub(crate) struct RustylineReader<H: Helper> {
     history_file: PathBuf,
     editor: Editor<H, FileHistory>,
+
+    interrupt_content_empty_ref: Arc<Mutex<bool>>,
 }
 
 impl<H: CommandDefinitions> RustylineReader<EditorHelper<H>> {
@@ -42,10 +45,9 @@ impl<H: CommandDefinitions> RustylineReader<EditorHelper<H>> {
             Event::Any,
             EventHandler::Conditional(Box::new(SearchHistoryModeReset { search_mode: search_mode.clone() })),
         );
-        editor.bind_sequence(
-            Event::from(KeyEvent::ctrl('c')),
-            EventHandler::Conditional(Box::new(InterruptIfEmptyElseClear {})),
-        );
+        let interrupt_handler = InterruptIfEmptyElseClear::new();
+        let interrupt_content_empty_ref = interrupt_handler.content_empty_ref();
+        editor.bind_sequence(Event::from(KeyEvent::ctrl('c')), EventHandler::Conditional(Box::new(interrupt_handler)));
         editor.bind_sequence(
             Event::from(KeyEvent(KeyCode::Up, Modifiers::NONE)),
             EventHandler::Conditional(Box::new(SearchHistory { forward: false, search_mode: search_mode.clone() })),
@@ -55,19 +57,27 @@ impl<H: CommandDefinitions> RustylineReader<EditorHelper<H>> {
             EventHandler::Conditional(Box::new(SearchHistory { forward: true, search_mode })),
         );
         let _ = editor.load_history(&history_file);
-        Self { editor, history_file }
+        Self { editor, history_file, interrupt_content_empty_ref }
     }
 
-    pub(crate) fn readline(&mut self, prompt: &str) -> rustyline::Result<String> {
+    pub(crate) fn readline(&mut self, prompt: &str) -> (rustyline::Result<String>, Option<bool>) {
         match self.editor.readline(prompt) {
             Ok(line) => {
                 let _ = self.editor.history_mut().add(line.trim_end());
                 let _ = self.editor.append_history(&self.history_file);
                 // Rustyline removes the last newline - we'll add back so the input matches what one would get from a  file
-                Ok(format!("{}\n", line))
+                (Ok(format!("{}\n", line)), None)
             }
-            Err(err) => Err(err),
+            Err(ReadlineError::Interrupted) => {
+                let interrupt_empty = self.interrupt_content_empty_ref.lock().unwrap().clone();
+                (Err(ReadlineError::Interrupted), Some(interrupt_empty))
+            }
+            Err(err) => (Err(err), None),
         }
+    }
+
+    pub(crate) fn print_external(&mut self, message: String) {
+        self.editor.create_external_printer().unwrap().print(message).unwrap()
     }
 }
 
@@ -116,15 +126,26 @@ impl<H: CommandDefinitions> Validator for EditorHelper<H> {
     }
 }
 
-struct InterruptIfEmptyElseClear {}
+struct InterruptIfEmptyElseClear {
+    interrupted_input_empty: Arc<Mutex<bool>>,
+}
+
+impl InterruptIfEmptyElseClear {
+    fn new() -> Self {
+        Self { interrupted_input_empty: Arc::new(Mutex::new(true)) }
+    }
+
+    fn content_empty_ref(&self) -> Arc<Mutex<bool>> {
+        self.interrupted_input_empty.clone()
+    }
+}
 
 impl ConditionalEventHandler for InterruptIfEmptyElseClear {
     fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, ctx: &rustyline::EventContext) -> Option<Cmd> {
-        if ctx.line().is_empty() {
-            Some(Cmd::Interrupt)
-        } else {
-            Some(Cmd::Kill(Movement::WholeBuffer))
+        if !ctx.line().is_empty() {
+            *self.content_empty_ref().lock().unwrap() = false;
         }
+        Some(Cmd::Interrupt)
     }
 }
 
@@ -179,14 +200,13 @@ impl ConditionalEventHandler for SearchHistory {
                     // stay in completion mode
                 }
             }
-
             match *self.search_mode.lock().unwrap() {
                 SearchMode::Normal => unreachable!("Must have picked a mode by the time we search searching."),
                 SearchMode::InNormalHistory => {
                     if self.forward {
-                        Some(Cmd::NextHistory)
+                        Some(Cmd::LineDownOrNextHistory(1))
                     } else {
-                        Some(Cmd::PreviousHistory)
+                        Some(Cmd::LineUpOrPreviousHistory(1))
                     }
                 }
                 SearchMode::InCompletion => {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -51,7 +51,7 @@ impl<Context: ReplContext + 'static> Repl<Context> {
         self
     }
 
-    pub(crate) fn get_input(&self) -> rustyline::Result<String> {
+    pub(crate) fn get_input(&self) -> (rustyline::Result<String>, Option<bool>) {
         let mut editor = RustylineReader::new(self.commands.clone(), self.history_file.clone(), self.multiline_input);
         editor.readline(&self.prompt)
     }


### PR DESCRIPTION
## Usage and product changes

We an important bug:
1.
```
>> match
$x isa person; |
```
2. navigate cursor and enter newlines
```
>> match

| $x isa person;
```

Various things would break, including submitting the "script" prematurely. Now, the block is only submitted when the sequence of commands entered are a valid script.

Additionally, the UX if Ctr+C is improved: when hitting Ctrl+C on a non-empty line, the line is retained, rather than cleared.

## Implementation
- hack around RustyLine to retain the previous line but not exit
- improve query/command submission logic
