### PR TITLE
Improve multiline query support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -144,6 +144,7 @@ release_validate_deps(
     refs = "@typedb_console_workspace_refs//:refs.json",
     tagged_deps = [
         "@typedb_driver",
+        "@typeql",
     ],
     tags = ["manual"], # in order for bazel test //... to not fail
     version_file = "VERSION",

--- a/BUILD
+++ b/BUILD
@@ -22,6 +22,7 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     deps = [
         "@typedb_driver//rust:typedb_driver",
+        "@typeql//rust:typeql",
 
         # External dependencies
         "@crates//:clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -306,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -367,6 +376,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +441,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +467,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -621,6 +659,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1252,6 +1300,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -1865,7 +1958,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "url",
  "uuid",
@@ -1902,6 +1995,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2042,7 +2146,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2050,6 +2163,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2099,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2326,12 +2450,13 @@ dependencies = [
  "tokio",
  "typedb-driver",
  "typedb_binary_runner",
+ "typeql",
 ]
 
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?tag=3.1.0#e216db8e177e37f4282e3c6572da0df4e8f4abeb"
+source = "git+https://github.com/typedb/typedb-driver?tag=3.2.0-rc0#a996fc106f9446f6a071eae05957ce294b44115b"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2353,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=7c7e24c43a59ac3e3b2c4bb17566eb9478099c21#7c7e24c43a59ac3e3b2c4bb17566eb9478099c21"
+source = "git+https://github.com/typedb/typedb-protocol?tag=3.2.0-rc0#195a37a3d28a6058ea501d75b276cadf6a38ad84"
 dependencies = [
  "prost",
  "tonic",
@@ -2367,6 +2492,30 @@ dependencies = [
  "clap",
  "tempdir",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "typeql"
+version = "0.0.0"
+source = "git+https://github.com/typedb/typeql?rev=377aac8847efde76e0c7f07fa56ee66fadd4d640#377aac8847efde76e0c7f07fa56ee66fadd4d640"
+dependencies = [
+ "chrono",
+ "itertools 0.10.5",
+ "pest",
+ "pest_derive",
+ "regex",
+]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uname"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,7 +2502,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=d6732c558b1e54f55eb0f89015bafe2aab2554b2#d6732c558b1e54f55eb0f89015bafe2aab2554b2"
+source = "git+https://github.com/typedb/typeql?rev=a5bde1c5e5bd2410894d6d266d53bfe02e6391c5#a5bde1c5e5bd2410894d6d266d53bfe02e6391c5"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,7 +2502,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=377aac8847efde76e0c7f07fa56ee66fadd4d640#377aac8847efde76e0c7f07fa56ee66fadd4d640"
+source = "git+https://github.com/typedb/typeql?rev=d91d5852e73592abe04899aca8efc023efda42ca#d91d5852e73592abe04899aca8efc023efda42ca"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,7 +2502,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=d91d5852e73592abe04899aca8efc023efda42ca#d91d5852e73592abe04899aca8efc023efda42ca"
+source = "git+https://github.com/typedb/typeql?rev=d6732c558b1e54f55eb0f89015bafe2aab2554b2#d6732c558b1e54f55eb0f89015bafe2aab2554b2"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "d91d5852e73592abe04899aca8efc023efda42ca"
+		rev = "d6732c558b1e54f55eb0f89015bafe2aab2554b2"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a5bde1c5e5bd2410894d6d266d53bfe02e6391c5"
+		rev = "7cbb621200f10f2cb741b57e82494ff9659813c6"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "d6732c558b1e54f55eb0f89015bafe2aab2554b2"
+		rev = "a5bde1c5e5bd2410894d6d266d53bfe02e6391c5"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,12 @@ features = {}
 		version = "0.3.2"
 		default-features = false
 
+	[dependencies.typeql]
+		features = []
+		rev = "377aac8847efde76e0c7f07fa56ee66fadd4d640"
+		git = "https://github.com/typedb/typeql"
+		default-features = false
+
 	[dependencies.typedb-driver]
 		features = []
 		git = "https://github.com/typedb/typedb-driver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "377aac8847efde76e0c7f07fa56ee66fadd4d640"
+		rev = "d91d5852e73592abe04899aca8efc023efda42ca"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -150,8 +150,9 @@ google_common_workspace_rules()
 #############################
 
 # Load repositories
-load("//dependencies/typedb:repositories.bzl", "typedb_driver")
+load("//dependencies/typedb:repositories.bzl", "typedb_driver", "typeql")
 typedb_driver()
+typeql()
 
 load("@typedb_driver//dependencies/typedb:repositories.bzl", "typedb_protocol")
 typedb_protocol()

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -22,5 +22,5 @@ def typeql():
     git_repository(
         name = "typeql",
         remote = "https://github.com/typedb/typeql",
-        tag = "3.2.0-rc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        commit = "2599c76e223e2f04c8dea3b64aa4da79abe8bbeb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -17,3 +17,10 @@ def typedb_driver():
         remote = "https://github.com/typedb/typedb-driver",
         tag = "3.2.0-rc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )
+
+def typeql():
+    git_repository(
+        name = "typeql",
+        remote = "https://github.com/typedb/typeql",
+        tag = "3.2.0-rc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+    )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -22,5 +22,5 @@ def typeql():
     git_repository(
         name = "typeql",
         remote = "https://github.com/typedb/typeql",
-        commit = "a5bde1c5e5bd2410894d6d266d53bfe02e6391c5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        commit = "7cbb621200f10f2cb741b57e82494ff9659813c6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -22,5 +22,5 @@ def typeql():
     git_repository(
         name = "typeql",
         remote = "https://github.com/typedb/typeql",
-        commit = "d6732c558b1e54f55eb0f89015bafe2aab2554b2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        commit = "a5bde1c5e5bd2410894d6d266d53bfe02e6391c5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -22,5 +22,5 @@ def typeql():
     git_repository(
         name = "typeql",
         remote = "https://github.com/typedb/typeql",
-        commit = "2599c76e223e2f04c8dea3b64aa4da79abe8bbeb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        commit = "d6732c558b1e54f55eb0f89015bafe2aab2554b2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,13 +32,12 @@ use crate::{
         user_delete, user_list, user_update_password,
     },
     repl::{
-        command::{get_word, parse_query_or_index_after_empty_line, CommandInput, CommandLeaf, Subcommand},
+        command::{get_word, parse_one_query, CommandInput, CommandLeaf, Subcommand},
         line_reader::LineReaderHidden,
         Repl, ReplContext,
     },
     runtime::BackgroundRuntime,
 };
-use crate::repl::command::log;
 
 mod cli;
 mod completions;
@@ -174,14 +173,7 @@ fn execute_interactive(context: &mut ConsoleContext) {
         match result {
             Ok(input) => {
                 if !input.trim().is_empty() {
-                    log(&format!("{:?}", input.as_bytes()));
-                    let is_pasted = input.starts_with(BRACKETED_PASTE_MODE_START);
-                    // the execute_all will drive the error handling and printing
-                    if is_pasted {
-                        let _ = execute_commands(context, &input, false, false);
-                    } else {
-                        let _ = execute_commands(context, &input, false, false);
-                    }
+                    let _ = execute_commands(context, &input, false, false);
                 } else {
                     continue;
                 }
@@ -352,7 +344,7 @@ fn transaction_repl(database: &str, transaction_type: TransactionType) -> Repl<C
         .add(CommandLeaf::new_with_input(
             "",
             "Execute query string.",
-            CommandInput::new("query", parse_query_or_index_after_empty_line, None, None),
+            CommandInput::new("query", parse_one_query, None, None),
             transaction_query,
         ));
     repl

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,7 @@ fn execute_command_list(context: &mut ConsoleContext, commands: &[String]) {
 }
 
 fn execute_interactive(context: &mut ConsoleContext) {
-    const BRACKETED_PASTE_MODE_START: &str = "\x1b[200~" ;
+    const BRACKETED_PASTE_MODE_START: &str = "\x1b[200~";
     println!("\nWelcome to TypeDB Console!\n");
     while !context.repl_stack.is_empty() {
         let repl_index = context.repl_stack.len() - 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,6 @@ fn execute_command_list(context: &mut ConsoleContext, commands: &[String]) {
 }
 
 fn execute_interactive(context: &mut ConsoleContext) {
-    const BRACKETED_PASTE_MODE_START: &str = "\x1b[200~";
     println!("\nWelcome to TypeDB Console!\n");
     while !context.repl_stack.is_empty() {
         let repl_index = context.repl_stack.len() - 1;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -14,7 +14,7 @@ use typedb_driver::{
 
 use crate::{
     printer::{print_document, print_row},
-    repl::command::{parse_query_or_index_after_empty_line, CommandResult, ReplError},
+    repl::command::{parse_one_query, CommandResult, ReplError},
     transaction_repl, ConsoleContext,
 };
 
@@ -243,7 +243,7 @@ pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])
 
     let mut input: &str = &contents;
     let mut query_count = 0;
-    while let Some(next_query_index) = parse_query_or_index_after_empty_line(&input, false) {
+    while let Some(next_query_index) = parse_one_query(&input, false) {
         let query = &input[0..next_query_index];
         if query.trim().is_empty() {
             input = &input[next_query_index..];

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -14,7 +14,7 @@ use typedb_driver::{
 
 use crate::{
     printer::{print_document, print_row},
-    repl::command::{index_after_empty_line, CommandResult, ReplError},
+    repl::command::{parse_query_or_index_after_empty_line, CommandResult, ReplError},
     transaction_repl, ConsoleContext,
 };
 
@@ -243,7 +243,7 @@ pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])
 
     let mut input: &str = &contents;
     let mut query_count = 0;
-    while let Some(next_query_index) = index_after_empty_line(&input, false) {
+    while let Some(next_query_index) = parse_query_or_index_after_empty_line(&input, false) {
         let query = &input[0..next_query_index];
         match execute_query(context, query.to_owned(), true) {
             Err(err) => {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -245,6 +245,10 @@ pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])
     let mut query_count = 0;
     while let Some(next_query_index) = parse_query_or_index_after_empty_line(&input, false) {
         let query = &input[0..next_query_index];
+        if query.trim().is_empty() {
+            input = &input[next_query_index..];
+            continue;
+        }
         match execute_query(context, query.to_owned(), true) {
             Err(err) => {
                 return Err(Box::new(ReplError {
@@ -263,7 +267,7 @@ pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String])
             }
         }
     }
-    if !input.is_empty() {
+    if !input.trim().is_empty() {
         match execute_query(context, input.to_owned(), false) {
             Err(err) => {
                 return Err(Box::new(ReplError {

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -4,14 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use rustyline::{
-    completion::{Completer, extract_word},
-    highlight::Highlighter,
-    hint::Hinter,
-};
-use typeql::common::error::TypeQLError;
-use typeql::parse_query_from;
-
 use std::{
     borrow::Cow,
     cmp::Ordering,
@@ -21,6 +13,13 @@ use std::{
     fmt::{Debug, Display, Formatter},
     rc::Rc,
 };
+
+use rustyline::{
+    completion::{extract_word, Completer},
+    highlight::Highlighter,
+    hint::Hinter,
+};
+use typeql::{common::error::TypeQLError, parse_query_from};
 
 use crate::repl::{line_reader::LineReaderHidden, ReplContext};
 
@@ -363,6 +362,10 @@ pub(crate) fn get_word(input: &str, _coerce_to_one_line: bool) -> Option<usize> 
     }
 }
 
+/// Read a maximum-length query from the input.
+/// This query must either be explicitly terminated with 'end', or be valid and have an empty following newline
+/// If there is a valid query, and the newline occurs much later, we still return that newline
+/// as that may the user's intended query end but there's a query parse error
 pub(crate) fn parse_one_query(mut input: &str, coerce_to_one_line: bool) -> Option<usize> {
     if coerce_to_one_line {
         Some(input.len())
@@ -370,19 +373,60 @@ pub(crate) fn parse_one_query(mut input: &str, coerce_to_one_line: bool) -> Opti
         // We maximally try to parse as many lines into a query as we can.
         // If we fail and there is no parseable query, we return the full string
         match typeql::parse_query_from(input) {
-            Ok((_query, mut after_query_pos)) => {
+            Ok((query, mut after_query_pos)) => {
                 // Note: Query parsing may consume any trailing whitespace, which we should undo
-                let tail_whitespace_count = (&input[0..after_query_pos]).chars().rev().take_while(|c| c.is_whitespace()).count();
+                let tail_whitespace_count =
+                    (&input[0..after_query_pos]).chars().rev().take_while(|c| c.is_whitespace()).count();
                 after_query_pos -= tail_whitespace_count;
-        
-                if after_query_pos > input.len() {
-                    return Some(input.len())
+
+                if query.has_explicit_end() {
+                    return Some(after_query_pos);
                 } else {
-                    return Some(after_query_pos)
+                    let remaining_input = &input[after_query_pos..];
+                    let after_newline_pos = find_empty_line(remaining_input);
+                    match after_newline_pos {
+                        None => None,
+                        Some(after_newline_pos) => Some(after_query_pos + after_newline_pos),
+                    }
                 }
             }
             Err(err) => {
-                Some(input.len())
+                // If we fail and there is no parseable query, we simply search for an empty newline and return that index
+                // sometimes TypeQL will hit an error, and stop parsing at that line even though it's not the end of a query
+                // this will degrade the query error pointer! So if we have a line number of the parsing error, we'll look for the newline
+                // after that line, instead of just the first newline
+                let mut start_line = 0;
+                let mut start_col = 0;
+                for error in err.errors() {
+                    if let TypeQLError::SyntaxErrorDetailed { error_line_nr, error_col, .. } = error {
+                        let line_nr = *error_line_nr - 1;
+                        if line_nr > start_line {
+                            start_line = line_nr;
+                            start_col = *error_col; //note: 1-indexed, but this works out to move the pos forward one to skip the first col
+                        }
+                    }
+                }
+                let mut after_error_pos = 0;
+                for _ in 0..start_line {
+                    const NEWLINE: &str = "\n";
+                    match input.find(NEWLINE) {
+                        None => {
+                            // unexpected, fall back behaviour
+                            return find_empty_line(input);
+                        }
+                        Some(pos) => {
+                            after_error_pos += pos + NEWLINE.len();
+                            input = &input[pos + NEWLINE.len()..]
+                        }
+                    }
+                }
+                after_error_pos += start_col;
+                let remaining_input = &input[start_col..];
+                let newline_after_error_pos = find_empty_line(remaining_input);
+                match newline_after_error_pos {
+                    None => None,
+                    Some(newline_after_error_pos) => Some(after_error_pos + newline_after_error_pos),
+                }
             }
         }
     }

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -19,6 +19,7 @@ use rustyline::{
     highlight::Highlighter,
     hint::Hinter,
 };
+use typeql::common::error::TypeQLError;
 
 use crate::repl::{line_reader::LineReaderHidden, ReplContext};
 
@@ -386,22 +387,59 @@ pub(crate) fn parse_query_or_index_after_empty_line(mut input: &str, coerce_to_o
         //   (Both of the two cases turn out to return the same index: query's end index == after empty newline index)
         //   If no empty line is found, we return None (query is valid, but not "terminated" with an empty line)
         // If we fail and there is no parseable query, we simply search for an empty newline and return that index
-        if let Ok((_query, mut after_query_pos)) = typeql::parse_query_from(input) {
-            // Note: Query parsing will consume any trailing whitespace, which we should undo
-            let tail_whitespace_count = (&input[0..after_query_pos]).chars().rev().take_while(|c| c.is_whitespace()).count();
-            after_query_pos -= tail_whitespace_count;
+        match typeql::parse_query_from(input) {
+            Ok((_query, mut after_query_pos)) => {
+                // Note: Query parsing will consume any trailing whitespace, which we should undo
+                let tail_whitespace_count = (&input[0..after_query_pos]).chars().rev().take_while(|c| c.is_whitespace()).count();
+                after_query_pos -= tail_whitespace_count;
 
-            if after_query_pos > input.len() {
-                return None
+                if after_query_pos > input.len() {
+                    return None
+                }
+                let remaining_input = &input[after_query_pos..];
+                let after_newline_pos = find_empty_line(remaining_input);
+                match after_newline_pos {
+                    None => None,
+                    Some(after_newline_pos) => Some(after_query_pos + after_newline_pos),
+                }
             }
-            let remaining_input = &input[after_query_pos..];
-            let after_newline_pos = find_empty_line(remaining_input);
-            match after_newline_pos {
-                None => None,
-                Some(after_newline_pos) => Some(after_query_pos + after_newline_pos),
+            Err(err) => {
+                // sometimes TypeQL will hit an error, and stop parsing at that line even though it's not the end of a query
+                // this will degrade the query error pointer! So if we have a line number of the parsing error, we'll look for the newline
+                // after that line, instead of just the first newline
+                let mut start_line = 0;
+                let mut start_col = 0;
+                for error in err.errors() {
+                    if let TypeQLError::SyntaxErrorDetailed { error_line_nr, error_col, .. } = error {
+                        let line_nr = *error_line_nr - 1;
+                        if line_nr > start_line {
+                            start_line = line_nr;
+                            start_col = *error_col; //note: 1-indexed, but this works out to move the pos forward one to skip the first col
+                        }
+                    }
+                }
+                let mut after_error_pos = 0;
+                for _ in 0..start_line {
+                    const NEWLINE: &str = "\n";
+                    match input.find(NEWLINE) {
+                        None => {
+                            // unexpected, fall back behaviour
+                            return find_empty_line(input)
+                        }
+                        Some(pos) => {
+                            after_error_pos += pos + NEWLINE.len();
+                            input = &input[pos + NEWLINE.len()..]
+                        }
+                    }
+                }
+                after_error_pos += start_col;
+                let remaining_input = &input[start_col..];
+                let newline_after_error_pos = find_empty_line(remaining_input);
+                match newline_after_error_pos {
+                    None => None,
+                    Some(newline_after_error_pos) => Some(after_error_pos + newline_after_error_pos),
+                }
             }
-        } else {
-            find_empty_line(input)
         }
     }
 }


### PR DESCRIPTION
## Usage and product changes

We improve multi-line query support to allow copy-pasting queries and scripts containing empty newlines. In particular this makes pasting entire schema definitions from files. 

For example, pasting a console script opening a transaction, defining a schema containing newlines, and committing, is now possible:
```
>> transaction schema test
    define 
      entity person;  # newlines are allowed in pasted scripts:
       
      attribute name, value string;
      
      person owns name; 
   
    commit
```

Empty newlines when written _interactively_ still cause queries to be submitted. However, an explicit query `end;` clause is a valid alternative now:

```
>> transaction schema test
    define 
      entity person;  # newlines are allowed in pasted scripts:
       
      attribute name, value string;
      
      person owns name; 
    end; # <--- will submit immediately
```

Pasted query pipelines may now be ambiguous, such as the following example which by defaults executs a single "match-insert" query, even though there are newlines:
```
> transaction schema test
  match $x isa person;

  insert $y isa person;

  commit
```

To make this a "match" query and a separate "insert" query, we must use the `end;` markers:
```
> transaction schema test
  match $x isa person;
  end;

  insert $y isa person;
  end;

  commit
```

**Note that now `end` is a reserved keyword and cannot be used as a type!**

## Implementation

Queries are now parsed using TypeQL when given input. A "maximum" query is parsed from the input at a time, so multi-query copy-paste and scripts need to take care to be include the right terminators between queries (eg "end;").

