### PR TITLE
Increase transaction timeout

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 use std::time::Duration;
 
 use crate::constants::common::SECONDS_IN_HOUR;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,16 @@
+use std::time::Duration;
+
+use typedb_driver::TransactionOptions;
+
+use crate::constants::common::SECONDS_IN_HOUR;
+
+pub mod common {
+    pub const SECONDS_IN_MINUTE: u64 = 60;
+    pub const MINUTES_IN_HOUR: u64 = 60;
+    pub const SECONDS_IN_HOUR: u64 = SECONDS_IN_MINUTE * MINUTES_IN_HOUR;
+
+    pub const ERROR_QUERY_POINTER_LINES_BEFORE: usize = 2;
+    pub const ERROR_QUERY_POINTER_LINES_AFTER: usize = 2;
+}
+
+pub const DEFAULT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(1 * SECONDS_IN_HOUR);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,16 +1,11 @@
 use std::time::Duration;
 
-use typedb_driver::TransactionOptions;
-
 use crate::constants::common::SECONDS_IN_HOUR;
 
 pub mod common {
     pub const SECONDS_IN_MINUTE: u64 = 60;
     pub const MINUTES_IN_HOUR: u64 = 60;
     pub const SECONDS_IN_HOUR: u64 = SECONDS_IN_MINUTE * MINUTES_IN_HOUR;
-
-    pub const ERROR_QUERY_POINTER_LINES_BEFORE: usize = 2;
-    pub const ERROR_QUERY_POINTER_LINES_AFTER: usize = 2;
 }
 
 pub const DEFAULT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(1 * SECONDS_IN_HOUR);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ use crate::{
 
 mod cli;
 mod completions;
+mod constants;
 mod operations;
 mod printer;
 mod repl;


### PR DESCRIPTION
## Usage and product changes
Set transaction timeout for opened transactions to 1 hour.

This change significantly lowers the impact of https://github.com/typedb/typedb-console/issues/287.

## Implementation
Use the new `transaction_with_options` interface of the Rust driver to pass configured transaction options.