### PR TITLE
Introduce database export and import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,9 +266,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1694,13 +1694,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.3.1"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?rev=b2341b75d9d4202468cfe834c5e5de186842e368#b2341b75d9d4202468cfe834c5e5de186842e368"
+source = "git+https://github.com/typedb/typedb-driver?rev=e3b3ab1df21c7bbeef6b3bfd9b1a040343fbb54a#e3b3ab1df21c7bbeef6b3bfd9b1a040343fbb54a"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=1480387a62e48b64b34d5d8626211c3d139e0465#1480387a62e48b64b34d5d8626211c3d139e0465"
+source = "git+https://github.com/typedb/typedb-protocol?rev=59ad51a9e9dcde8e5ac47015be7956f9b2b27fef#59ad51a9e9dcde8e5ac47015be7956f9b2b27fef"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?rev=3fe2be96066d0e3ed64654b3b3bcfed9554acafb#3fe2be96066d0e3ed64654b3b3bcfed9554acafb"
+source = "git+https://github.com/typedb/typedb-driver?rev=6db6f947bbc8f47181f81f458f1f09e1985fb514#6db6f947bbc8f47181f81f458f1f09e1985fb514"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?tag=3.2.0#b9b84673130a110dbb80b474037cefeb867fc780"
+source = "git+https://github.com/typedb/typedb-driver?rev=0e484c59ea9846ce80f94bb96e4f61f7bdfa0e57#0e484c59ea9846ce80f94bb96e4f61f7bdfa0e57"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?tag=3.2.0#d4350c004c5d44436b256f291a3ecbaad77dae64"
+source = "git+https://github.com/typedb/typedb-protocol?rev=9ef738d2e0f5d9ebb57d1281a66b38267c430c15#9ef738d2e0f5d9ebb57d1281a66b38267c430c15"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?rev=0e484c59ea9846ce80f94bb96e4f61f7bdfa0e57#0e484c59ea9846ce80f94bb96e4f61f7bdfa0e57"
+source = "git+https://github.com/typedb/typedb-driver?rev=b2341b75d9d4202468cfe834c5e5de186842e368#b2341b75d9d4202468cfe834c5e5de186842e368"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=9ef738d2e0f5d9ebb57d1281a66b38267c430c15#9ef738d2e0f5d9ebb57d1281a66b38267c430c15"
+source = "git+https://github.com/typedb/typedb-protocol?rev=1480387a62e48b64b34d5d8626211c3d139e0465#1480387a62e48b64b34d5d8626211c3d139e0465"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?rev=e3b3ab1df21c7bbeef6b3bfd9b1a040343fbb54a#e3b3ab1df21c7bbeef6b3bfd9b1a040343fbb54a"
+source = "git+https://github.com/typedb/typedb-driver?rev=3fe2be96066d0e3ed64654b3b3bcfed9554acafb#3fe2be96066d0e3ed64654b3b3bcfed9554acafb"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=59ad51a9e9dcde8e5ac47015be7956f9b2b27fef#59ad51a9e9dcde8e5ac47015be7956f9b2b27fef"
+source = "git+https://github.com/typedb/typedb-protocol?rev=f6528beec33d6e3c31cb5dafc30e8f0f097c3f82#f6528beec33d6e3c31cb5dafc30e8f0f097c3f82"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ features = {}
 
 	[dependencies.tokio]
 		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.44.2"
+		version = "1.45.0"
 		default-features = false
 
 	[dependencies.rustyline]
@@ -30,7 +30,7 @@ features = {}
 
 	[dependencies.clap]
 		features = ["color", "default", "derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"]
-		version = "4.5.36"
+		version = "4.5.38"
 		default-features = false
 
 	[dependencies.glob]
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typedb-driver]
 		features = []
-		rev = "b2341b75d9d4202468cfe834c5e5de186842e368"
+		rev = "e3b3ab1df21c7bbeef6b3bfd9b1a040343fbb54a"
 		git = "https://github.com/typedb/typedb-driver"
 		default-features = false
 
@@ -62,7 +62,7 @@ features = {}
 
 	[dependencies.rpassword]
 		features = []
-		version = "7.3.1"
+		version = "7.4.0"
 		default-features = false
 
 	[dependencies.home]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typedb-driver]
 		features = []
-		rev = "3fe2be96066d0e3ed64654b3b3bcfed9554acafb"
+		rev = "6db6f947bbc8f47181f81f458f1f09e1985fb514"
 		git = "https://github.com/typedb/typedb-driver"
 		default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typedb-driver]
 		features = []
-		rev = "e3b3ab1df21c7bbeef6b3bfd9b1a040343fbb54a"
+		rev = "3fe2be96066d0e3ed64654b3b3bcfed9554acafb"
 		git = "https://github.com/typedb/typedb-driver"
 		default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typedb-driver]
 		features = []
-		rev = "0e484c59ea9846ce80f94bb96e4f61f7bdfa0e57"
+		rev = "b2341b75d9d4202468cfe834c5e5de186842e368"
 		git = "https://github.com/typedb/typedb-driver"
 		default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ features = {}
 
 	[dependencies.typedb-driver]
 		features = []
+		rev = "0e484c59ea9846ce80f94bb96e4f61f7bdfa0e57"
 		git = "https://github.com/typedb/typedb-driver"
-		tag = "3.2.0"
 		default-features = false
 
 	[dependencies.futures]

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -12,11 +12,10 @@ def typedb_dependencies():
     )
 
 def typedb_driver():
-    # TODO: Return typedb
     git_repository(
         name = "typedb_driver",
-        remote = "https://github.com/farost/typedb-driver",
-        commit = "3fe2be96066d0e3ed64654b3b3bcfed9554acafb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        remote = "https://github.com/typedb/typedb-driver",
+        commit = "6db6f947bbc8f47181f81f458f1f09e1985fb514",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )
 
 def typeql():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -17,7 +17,7 @@ def typedb_driver():
     git_repository(
         name = "typedb_driver",
         remote = "https://github.com/farost/typedb-driver",
-        commit = "167e989b87a856dbe5274af827c5190bed33d2ee",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        commit = "e3b3ab1df21c7bbeef6b3bfd9b1a040343fbb54a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )
 
 def typeql():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -5,11 +5,10 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def typedb_dependencies():
-    # TODO: Return typedb
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/farost/typedb-dependencies",
-        commit = "b198f8d11a0b437ee9f9cf1e4eead8bedcdb7312", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/typedb/typedb-dependencies",
+        commit = "4ffeaabde31c41cee271cbb563f17168f4229a93", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typedb_driver():
@@ -17,7 +16,7 @@ def typedb_driver():
     git_repository(
         name = "typedb_driver",
         remote = "https://github.com/farost/typedb-driver",
-        commit = "8ff2b2d5da375eaee13baf9e8167f51d74a79bdc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        commit = "3fe2be96066d0e3ed64654b3b3bcfed9554acafb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )
 
 def typeql():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -17,7 +17,7 @@ def typedb_driver():
     git_repository(
         name = "typedb_driver",
         remote = "https://github.com/farost/typedb-driver",
-        commit = "e3b3ab1df21c7bbeef6b3bfd9b1a040343fbb54a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        commit = "8ff2b2d5da375eaee13baf9e8167f51d74a79bdc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )
 
 def typeql():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -5,23 +5,20 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def typedb_dependencies():
+    # TODO: Return typedb
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "ab777bf067b1930e35146fd8e25a76a4a360aa74", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/farost/typedb-dependencies",
+        commit = "b198f8d11a0b437ee9f9cf1e4eead8bedcdb7312", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typedb_driver():
     # TODO: Return typedb
-    native.local_repository(
+    git_repository(
         name = "typedb_driver",
-        path = "../typedb-driver",
+        remote = "https://github.com/farost/typedb-driver",
+        commit = "167e989b87a856dbe5274af827c5190bed33d2ee",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )
-#    git_repository(
-#        name = "typedb_driver",
-#        remote = "https://github.com/farost/typedb-driver",
-#        commit = "0e484c59ea9846ce80f94bb96e4f61f7bdfa0e57",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
-#    )
 
 def typeql():
     git_repository(

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -12,11 +12,16 @@ def typedb_dependencies():
     )
 
 def typedb_driver():
-    git_repository(
+    # TODO: Return typedb
+    native.local_repository(
         name = "typedb_driver",
-        remote = "https://github.com/typedb/typedb-driver",
-        tag = "3.2.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        path = "../typedb-driver",
     )
+#    git_repository(
+#        name = "typedb_driver",
+#        remote = "https://github.com/farost/typedb-driver",
+#        commit = "0e484c59ea9846ce80f94bb96e4f61f7bdfa0e57",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+#    )
 
 def typeql():
     git_repository(

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,9 +28,10 @@ use crate::{
     cli::Args,
     completions::{database_name_completer_fn, file_completer},
     operations::{
-        database_create, database_delete, database_list, database_schema, transaction_close, transaction_commit,
-        transaction_query, transaction_read, transaction_rollback, transaction_schema, transaction_source,
-        transaction_write, user_create, user_delete, user_list, user_update_password,
+        database_create, database_delete, database_export, database_import, database_list, database_schema,
+        transaction_close, transaction_commit, transaction_query, transaction_read, transaction_rollback,
+        transaction_schema, transaction_source, transaction_write, user_create, user_delete, user_list,
+        user_update_password,
     },
     repl::{
         command::{get_word, parse_one_query, CommandInput, CommandLeaf, Subcommand},
@@ -293,6 +294,31 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
             "Retrieve the TypeQL representation of a database's schema.",
             CommandInput::new("db", get_word, None, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
             database_schema,
+        ))
+        .add(CommandLeaf::new_with_inputs(
+            "import",
+            "Create a new database with the given name based on another exported database.",
+            vec![
+                CommandInput::new("db", get_word, None, None),
+                CommandInput::new("schema file path", get_word, None, None),
+                CommandInput::new("data file path", get_word, None, None),
+            ],
+            database_import,
+        ))
+        .add(CommandLeaf::new_with_inputs(
+            "export",
+            "Export a database into a .tql schema definition and a .typedb data file.",
+            vec![
+                CommandInput::new(
+                    "db",
+                    get_word,
+                    None,
+                    Some(database_name_completer_fn(driver.clone(), runtime.clone())),
+                ),
+                CommandInput::new("schema file path", get_word, None, None),
+                CommandInput::new("data file path", get_word, None, None),
+            ],
+            database_export,
         ));
 
     let user_commands = Subcommand::new("user")

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,7 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
         ))
         .add(CommandLeaf::new_with_inputs(
             "import",
-            "Create a new database with the given name based on another exported database.",
+            "Create a database with the given name based on another previously exported database.",
             vec![
                 CommandInput::new("db", get_word, None, None),
                 CommandInput::new("schema file path", get_word, None, None),
@@ -307,7 +307,7 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
         ))
         .add(CommandLeaf::new_with_inputs(
             "export",
-            "Export a database into a .tql schema definition and a .typedb data file.",
+            "Export a database into a schema definition and a data files.",
             vec![
                 CommandInput::new(
                     "db",

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -55,8 +55,9 @@ pub(crate) fn database_create(context: &mut ConsoleContext, input: &[String]) ->
 pub(crate) fn database_import(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let db_name = input[0].clone();
-    let schema = read_to_string(input[1].clone()).map_err(|err| Box::new(err) as Box<dyn Error + Send>)?;
-    let data_file_path: PathBuf = input[2].clone().into();
+    let schema =
+        read_to_string(context.convert_path(&input[1])).map_err(|err| Box::new(err) as Box<dyn Error + Send>)?;
+    let data_file_path: PathBuf = context.convert_path(&input[2]);
     context
         .background_runtime
         .run(async move { driver.databases().import_from_file(db_name, schema, data_file_path).await })
@@ -68,8 +69,8 @@ pub(crate) fn database_import(context: &mut ConsoleContext, input: &[String]) ->
 pub(crate) fn database_export(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let db_name = input[0].clone();
-    let schema_file_path: PathBuf = input[1].clone().into();
-    let data_file_path: PathBuf = input[2].clone().into();
+    let schema_file_path: PathBuf = context.convert_path(&input[1]);
+    let data_file_path: PathBuf = context.convert_path(&input[2]);
     context
         .background_runtime
         .run(async move {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -52,6 +52,37 @@ pub(crate) fn database_create(context: &mut ConsoleContext, input: &[String]) ->
     Ok(())
 }
 
+pub(crate) fn database_import(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
+    let driver = context.driver.clone();
+    let db_name = input[0].clone();
+    let schema_file_path: PathBuf = input[1].clone().into();
+    let schema = "define ...;".to_string(); // TODO: temp
+    let data_file_path: PathBuf = input[2].clone().into();
+    println!("PATH: schema: {schema_file_path:?}, data: {data_file_path:?}, NAME: {db_name}");
+    context
+        .background_runtime
+        .run(async move { driver.databases().import(db_name, schema, data_file_path).await })
+        .map_err(|err| Box::new(err) as Box<dyn Error + Send>)?;
+    println!("Successfully imported database.");
+    Ok(())
+}
+
+pub(crate) fn database_export(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
+    let driver = context.driver.clone();
+    let db_name = input[0].clone();
+    let schema_file_path: PathBuf = input[1].clone().into();
+    let data_file_path: PathBuf = input[2].clone().into();
+    context
+        .background_runtime
+        .run(async move {
+            let db = driver.databases().get(db_name).await?;
+            db.export(schema_file_path, data_file_path).await
+        })
+        .map_err(|err| Box::new(err) as Box<dyn Error + Send>)?;
+    println!("Successfully exported database.");
+    Ok(())
+}
+
 pub(crate) fn database_delete(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let driver = context.driver.clone();
     let db_name = input[0].clone();

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -59,7 +59,7 @@ pub(crate) fn database_import(context: &mut ConsoleContext, input: &[String]) ->
     let data_file_path: PathBuf = input[2].clone().into();
     context
         .background_runtime
-        .run(async move { driver.databases().import_file(db_name, schema, data_file_path).await })
+        .run(async move { driver.databases().import_from_file(db_name, schema, data_file_path).await })
         .map_err(|err| Box::new(err) as Box<dyn Error + Send>)?;
     println!("Successfully imported database.");
     Ok(())
@@ -74,7 +74,7 @@ pub(crate) fn database_export(context: &mut ConsoleContext, input: &[String]) ->
         .background_runtime
         .run(async move {
             let db = driver.databases().get(db_name).await?;
-            db.export_file(schema_file_path, data_file_path).await
+            db.export_to_file(schema_file_path, data_file_path).await
         })
         .map_err(|err| Box::new(err) as Box<dyn Error + Send>)?;
     println!("Successfully exported database.");

--- a/tool/runner/Cargo.toml
+++ b/tool/runner/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.clap]
 		features = ["color", "default", "derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"]
-		version = "4.5.36"
+		version = "4.5.38"
 		default-features = false
 
 	[dependencies.tempdir]


### PR DESCRIPTION
## Usage and product changes
Add database export and database import operations. 

Database export saves the database information (its schema and data) on the client machine as two files at provided locations:
```
# database export <name> <schema file location> <data file location>
database export my-database export/my-database.typeql export/my-database.typedb
```

Database import uses the exported files to create a new database with equivalent schema and data:
```
# database export <name> <schema file location> <data file location>
database import their-database export/my-database.typeql export/my-database.typedb
```

## Implementation
Add new commands similar to other `database` interfaces. Prepare data to call the respective [typedb-driver APIs](https://github.com/typedb/typedb-driver/pull/758).
