### PR TITLE
Support relative script and source commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,8 @@ pub struct Args {
 
     /// Executes all console commands directly from the script(s) in the order of each specified script.
     /// Exits if any script errors at any point.
-    /// Files must follow the convention of terminating queries with an empty newline
+    /// Files must follow the convention of terminating queries with an empty newline.
+    /// File path can be absolute or relative to the current directory
     #[arg(long, value_name = "path to script file")]
     pub script: Vec<String>,
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -252,13 +252,7 @@ pub(crate) fn transaction_rollback(context: &mut ConsoleContext, _input: &[Strin
 
 pub(crate) fn transaction_source(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
     let file_str = &input[0];
-    let mut path = PathBuf::from(file_str);
-    if !path.is_absolute() {
-        match context.script_dir.as_ref() {
-            None => path = context.invocation_dir.join(path),
-            Some(dir) => path = PathBuf::from(dir).join(path),
-        }
-    }
+    let path = context.convert_path(file_str);
     if !path.exists() {
         return Err(Box::new(ReplError { message: format!("File not found: {}", path.to_string_lossy()) })
             as Box<dyn Error + Send>);

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -18,8 +18,6 @@ pub(crate) mod line_reader;
 
 pub(crate) trait ReplContext: Sized {
     fn current_repl(&self) -> &Repl<Self>;
-
-    fn has_changes(&self) -> bool;
 }
 
 pub(crate) struct Repl<Context> {


### PR DESCRIPTION
## Usage and product changes

We support using relative paths for the `--script` command (relative to the current directory), as well as relative paths for the REPL `source` command.

When `source` is invoked _from_ a script, the sourced file is relativised to the script, rather than the current working directory.

## Implementation

* Store the console's working directory, and the script directory if a script is active (scripts can't be nested, which enables this!)
* Relativize to either the script directory or the working directory as when running with `--script` mode and `>> source <path>
` commands