### PR TITLE
Update zlib dependency 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?rev=8e37a8846f5bb774cb976770e90f962b37603da2#8e37a8846f5bb774cb976770e90f962b37603da2"
+source = "git+https://github.com/typedb/typedb-driver?rev=3b171274a42751376b2a480baa40315ebbf80fce#3b171274a42751376b2a480baa40315ebbf80fce"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=92d992f3c667acbf460786401b11281df4437e72#92d992f3c667acbf460786401b11281df4437e72"
+source = "git+https://github.com/typedb/typedb-protocol?rev=38f66a1cc4db3b7a301676f50800e9530ac5c8a3#38f66a1cc4db3b7a301676f50800e9530ac5c8a3"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?tag=3.4.0-rc0#3468564083c89fe0290a06ec213a15c61a2754ee"
+source = "git+https://github.com/typedb/typedb-driver?rev=8e37a8846f5bb774cb976770e90f962b37603da2#8e37a8846f5bb774cb976770e90f962b37603da2"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?tag=3.4.0-rc0#1d5bf80cdcd9801df9ef78056451143e755e0d30"
+source = "git+https://github.com/typedb/typedb-protocol?rev=92d992f3c667acbf460786401b11281df4437e72#92d992f3c667acbf460786401b11281df4437e72"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ features = {}
 
 	[dependencies.typedb-driver]
 		features = []
+		rev = "8e37a8846f5bb774cb976770e90f962b37603da2"
 		git = "https://github.com/typedb/typedb-driver"
-		tag = "3.4.0-rc0"
 		default-features = false
 
 	[dependencies.futures]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typedb-driver]
 		features = []
-		rev = "8e37a8846f5bb774cb976770e90f962b37603da2"
+		rev = "3b171274a42751376b2a480baa40315ebbf80fce"
 		git = "https://github.com/typedb/typedb-driver"
 		default-features = false
 

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -5,19 +5,17 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def typedb_dependencies():
-    # TODO: return typedb
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/farost/typedb-dependencies",
-        commit = "24a0d12e3523c96a349e0742435194423f2dd1f9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/typedb/typedb-dependencies",
+        commit = "fac1121c903b0c9e5924d391a883e4a0749a82a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typedb_driver():
-    # TODO: return typedb
     git_repository(
         name = "typedb_driver",
-        remote = "https://github.com/farost/typedb-driver",
-        commit = "8e37a8846f5bb774cb976770e90f962b37603da2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        remote = "https://github.com/typedb/typedb-driver",
+        commit = "3b171274a42751376b2a480baa40315ebbf80fce",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )
 
 def typeql():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -5,17 +5,19 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def typedb_dependencies():
+    # TODO: return typedb
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "4ffeaabde31c41cee271cbb563f17168f4229a93", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/farost/typedb-dependencies",
+        commit = "24a0d12e3523c96a349e0742435194423f2dd1f9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typedb_driver():
+    # TODO: return typedb
     git_repository(
         name = "typedb_driver",
-        remote = "https://github.com/typedb/typedb-driver",
-        tag = "3.4.0-rc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        remote = "https://github.com/farost/typedb-driver",
+        commit = "8e37a8846f5bb774cb976770e90f962b37603da2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )
 
 def typeql():


### PR DESCRIPTION
## Usage and product changes
Support build on Apple Clang 17+ by updating dependencies (details: https://github.com/typedb/typedb-dependencies/pull/577). 

## Implementation
