### PR TITLE
Introduce 'create-init' command to load a new database from schema/data

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -33,6 +33,7 @@ rust_binary(
         "@crates//:rustyline",
         "@crates//:sentry",
         "@crates//:serde_json",
+        "@crates//:sha2",
         "@crates//:ureq",
         "@crates//:tokio",
     ],

--- a/BUILD
+++ b/BUILD
@@ -33,6 +33,7 @@ rust_binary(
         "@crates//:rustyline",
         "@crates//:sentry",
         "@crates//:serde_json",
+        "@crates//:ureq",
         "@crates//:tokio",
     ],
     compile_data = ["//:VERSION"],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +555,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2451,12 +2470,13 @@ dependencies = [
  "typedb-driver",
  "typedb_binary_runner",
  "typeql",
+ "ureq",
 ]
 
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?tag=3.4.4#ca07f77759f7b5ca4044429f112f3866e7115424"
+source = "git+https://github.com/typedb/typedb-driver?tag=3.4.0#337851667eb7c74d45643d4411f7af3499d8817a"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2566,9 +2586,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64",
+ "flate2",
  "log",
  "once_cell",
+ "rustls",
+ "rustls-pki-types",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2710,6 +2734,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2466,6 +2466,7 @@ dependencies = [
  "rustyline",
  "sentry",
  "serde_json",
+ "sha2",
  "tokio",
  "typedb-driver",
  "typedb_binary_runner",
@@ -2476,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?tag=3.4.0#337851667eb7c74d45643d4411f7af3499d8817a"
+source = "git+https://github.com/typedb/typedb-driver?tag=3.4.4#ca07f77759f7b5ca4044429f112f3866e7115424"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,31 @@ features = {}
 		version = "1.45.0"
 		default-features = false
 
+	[dependencies.glob]
+		features = []
+		version = "0.3.2"
+		default-features = false
+
+	[dependencies.futures]
+		features = ["alloc", "async-await", "default", "executor", "futures-executor", "std", "thread-pool"]
+		version = "0.3.31"
+		default-features = false
+
+	[dependencies.rpassword]
+		features = []
+		version = "7.4.0"
+		default-features = false
+
+	[dependencies.home]
+		features = []
+		version = "0.5.11"
+		default-features = false
+
+	[dependencies.sha2]
+		features = ["default", "std"]
+		version = "0.10.9"
+		default-features = false
+
 	[dependencies.rustyline]
 		features = ["custom-bindings", "fd-lock", "radix_trie", "with-file-history"]
 		version = "15.0.0"
@@ -31,11 +56,6 @@ features = {}
 	[dependencies.clap]
 		features = ["color", "default", "derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"]
 		version = "4.5.38"
-		default-features = false
-
-	[dependencies.glob]
-		features = []
-		version = "0.3.2"
 		default-features = false
 
 	[dependencies.typeql]
@@ -50,24 +70,9 @@ features = {}
 		tag = "3.4.4"
 		default-features = false
 
-	[dependencies.futures]
-		features = ["alloc", "async-await", "default", "executor", "futures-executor", "std", "thread-pool"]
-		version = "0.3.31"
-		default-features = false
-
 	[dependencies.serde_json]
 		features = ["alloc", "default", "indexmap", "preserve_order", "raw_value", "std"]
 		version = "1.0.140"
-		default-features = false
-
-	[dependencies.rpassword]
-		features = []
-		version = "7.4.0"
-		default-features = false
-
-	[dependencies.home]
-		features = []
-		version = "0.5.11"
 		default-features = false
 
 	[dependencies.sentry]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,11 @@ features = {}
 		version = "0.36.0"
 		default-features = false
 
+	[dependencies.ureq]
+		features = ["default", "gzip", "tls"]
+		version = "2.12.1"
+		default-features = false
+
 [[test]]
 	path = "tests/assembly/test_assembly.rs"
 	name = "test-assembly-native"

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ platform-specific distribution.
 
 ## Command line arguments
 
-You can provide several command arguments when running console in the terminal.
+You can provide several command arguments when running console in the terminal, of which the typically-used ones are:
 
 - `--username=<username>` : TypeDB server username to log in with (mandatory).
-- `--address=<address>` : TypeDB server address to which the console will connect to (mandatory). Ensure it is prefixed with `https://` when using TLS.
+- `--address=<address>` : TypeDB server address to which the console will connect to (mandatory)
 - `--script=<path>` : Run commands in the script file in non-interactive mode.
 - `--command=<command1> --command=<command2> ...` : Run commands in non-interactive mode.
 - `-V, --version` : Print version information and exit.
@@ -53,8 +53,6 @@ For TypeDB Cloud deployments, there is **no reason to use this setting** as they
 Alternatively, you may securely connect by managing your own certificates for both the client-side and server-side,
 and provide your certificate to the console with:
 `--tls-root-ca=<path>`
-
-See documentation at https://typedb.com/docs/manual/configure/encryption for further details.
 
 ## Console commands
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,10 @@ use crate::{
     cli::{Args, ADDRESS_VALUE_NAME, USERNAME_VALUE_NAME},
     completions::{database_name_completer_fn, file_completer},
     operations::{
-        database_create, database_create_init, database_delete, database_export, database_import, database_list, database_schema,
-        transaction_close, transaction_commit, transaction_query, transaction_read, transaction_rollback,
-        transaction_schema, transaction_source, transaction_write, user_create, user_delete, user_list,
-        user_update_password,
+        database_create, database_create_init, database_delete, database_export, database_import, database_list,
+        database_schema, transaction_close, transaction_commit, transaction_query, transaction_read,
+        transaction_rollback, transaction_schema, transaction_source, transaction_write, user_create, user_delete,
+        user_list, user_update_password,
     },
     repl::{
         command::{get_word, parse_one_query, CommandInput, CommandLeaf, Subcommand},
@@ -318,7 +318,8 @@ fn execute_commands(
                 match command.execute(context, arguments) {
                     Ok(_) => &input[next_command_index..],
                     Err(err) => {
-                        let message = format!("**Error executing command**\n{}\n--> Error\n{}", command_string.trim(), err);
+                        let message =
+                            format!("**Error executing command**\n{}\n--> Error\n{}", command_string.trim(), err);
                         println_error!("{}", message);
                         return Err(CommandError { message });
                     }
@@ -398,7 +399,7 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
             "create",
             "Create new user.",
             vec![
-                CommandInput::new_required("name", get_word,  None),
+                CommandInput::new_required("name", get_word, None),
                 CommandInput::new_hidden("password", get_word, get_word, None),
             ],
             user_create,
@@ -423,19 +424,31 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
         .add(CommandLeaf::new_with_input(
             "read",
             "Open read transaction.",
-            CommandInput::new_required("db", get_word, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
+            CommandInput::new_required(
+                "db",
+                get_word,
+                Some(database_name_completer_fn(driver.clone(), runtime.clone())),
+            ),
             transaction_read,
         ))
         .add(CommandLeaf::new_with_input(
             "write",
             "Open write transaction.",
-            CommandInput::new_required("db", get_word, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
+            CommandInput::new_required(
+                "db",
+                get_word,
+                Some(database_name_completer_fn(driver.clone(), runtime.clone())),
+            ),
             transaction_write,
         ))
         .add(CommandLeaf::new_with_input(
             "schema",
             "Open schema transaction.",
-            CommandInput::new_required("db", get_word, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
+            CommandInput::new_required(
+                "db",
+                get_word,
+                Some(database_name_completer_fn(driver.clone(), runtime.clone())),
+            ),
             transaction_schema,
         ));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use crate::{
     cli::{Args, ADDRESS_VALUE_NAME, USERNAME_VALUE_NAME},
     completions::{database_name_completer_fn, file_completer},
     operations::{
-        database_create, database_delete, database_export, database_import, database_list, database_schema,
+        database_create, database_create_init, database_delete, database_export, database_import, database_list, database_schema,
         transaction_close, transaction_commit, transaction_query, transaction_read, transaction_rollback,
         transaction_schema, transaction_source, transaction_write, user_create, user_delete, user_list,
         user_update_password,
@@ -343,6 +343,16 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
             CommandInput::new("db", get_word, None, None),
             database_create,
         ))
+        .add(CommandLeaf::new_with_inputs(
+            "create-init",
+            "Create a new database with the given name and run schema and data from files. Files may be HTTP resources, or absolute or relative paths. Files are treated identically to 'transaction source' commands run explicitly.",
+            vec![
+                CommandInput::new("db", get_word, None, None),
+                CommandInput::new("schema file", get_word, None, None),
+                CommandInput::new("data file", get_word, None, None),
+            ],
+            database_create_init,
+        ))
         .add(CommandLeaf::new_with_input(
             "delete",
             "Delete the database with the given name.",
@@ -357,7 +367,7 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
         ))
         .add(CommandLeaf::new_with_inputs(
             "import",
-            "Create a database with the given name based on another previously exported database.",
+            "Create a database with the given name based on another previously exported database. File paths must be absolute or relative paths on the local machine.",
             vec![
                 CommandInput::new("db", get_word, None, None),
                 CommandInput::new("schema file path", get_word, None, None),
@@ -459,7 +469,7 @@ fn transaction_repl(database: &str, transaction_type: TransactionType) -> Repl<C
         ))
         .add(CommandLeaf::new_with_input(
             "source",
-            "Synchronously execute a file containing a sequence of TypeQL queries with full validation. Queries can be explicitly ended with 'end;' if required. Path may be absolute or relative to the invoking script (if there is one) otherwise relative to the current working directory.",
+            "Synchronously execute a file containing a sequence of TypeQL queries with full validation. Queries can be explicitly ended with 'end;' if required. May be a HTTP resource, an absolute path, or a path relative to the invoking script (if there is one) else a path relative to the current working directory.",
             CommandInput::new("file", get_word, None, Some(Box::new(file_completer))),
             transaction_source,
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,7 +345,7 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
         ))
         .add(CommandLeaf::new_with_inputs(
             "create-init",
-            "Create a new database with the given name and run schema and data from files. Files may be HTTP resources, or absolute or relative paths. Files are treated identically to 'transaction source' commands run explicitly.",
+            "Create a new database with the given name and load schema and data from files. Files may be HTTP-hosted files, or absolute or relative paths. File contents are treated identically to 'transaction source' commands run explicitly, and may contain multiple queries separated by 'end;' markers.",
             vec![
                 CommandInput::new("db", get_word, None, None),
                 CommandInput::new("schema file", get_word, None, None),
@@ -469,7 +469,7 @@ fn transaction_repl(database: &str, transaction_type: TransactionType) -> Repl<C
         ))
         .add(CommandLeaf::new_with_input(
             "source",
-            "Synchronously execute a file containing a sequence of TypeQL queries with full validation. Queries can be explicitly ended with 'end;' if required. May be a HTTP resource, an absolute path, or a path relative to the invoking script (if there is one) else a path relative to the current working directory.",
+            "Synchronously execute a file containing a sequence of TypeQL queries with full validation. Queries can be explicitly ended with 'end;' if required. May be a HTTP-hosted file, an absolute path, or a path relative to the invoking script (if there is one) else a path relative to the current working directory.",
             CommandInput::new("file", get_word, None, Some(Box::new(file_completer))),
             transaction_source,
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,38 +340,40 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
         .add(CommandLeaf::new_with_input(
             "create",
             "Create a new database with the given name.",
-            CommandInput::new("db", get_word, None, None),
+            CommandInput::new_required("db", get_word, None),
             database_create,
         ))
         .add(CommandLeaf::new_with_inputs(
             "create-init",
             "Create a new database with the given name and load schema and data from files. Files may be HTTP-hosted files, or absolute or relative paths. File contents are treated identically to 'transaction source' commands run explicitly, and may contain multiple queries separated by 'end;' markers.",
             vec![
-                CommandInput::new("db", get_word, None, None),
-                CommandInput::new("schema file", get_word, None, None),
-                CommandInput::new("data file", get_word, None, None),
+                CommandInput::new_required("db", get_word, None),
+                CommandInput::new_required("schema file", get_word, None),
+                CommandInput::new_required("data file", get_word, None),
+                CommandInput::new_required("schema file sha256", get_word, None),
+                CommandInput::new_required("data file sha256", get_word, None),
             ],
             database_create_init,
         ))
         .add(CommandLeaf::new_with_input(
             "delete",
             "Delete the database with the given name.",
-            CommandInput::new("db", get_word, None, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
+            CommandInput::new_required("db", get_word, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
             database_delete,
         ))
         .add(CommandLeaf::new_with_input(
             "schema",
             "Retrieve the TypeQL representation of a database's schema.",
-            CommandInput::new("db", get_word, None, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
+            CommandInput::new_required("db", get_word, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
             database_schema,
         ))
         .add(CommandLeaf::new_with_inputs(
             "import",
             "Create a database with the given name based on another previously exported database. File paths must be absolute or relative paths on the local machine.",
             vec![
-                CommandInput::new("db", get_word, None, None),
-                CommandInput::new("schema file path", get_word, None, None),
-                CommandInput::new("data file path", get_word, None, None),
+                CommandInput::new_required("db", get_word, None),
+                CommandInput::new_required("schema file path", get_word, None),
+                CommandInput::new_required("data file path", get_word, None),
             ],
             database_import,
         ))
@@ -379,14 +381,13 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
             "export",
             "Export a database into a schema definition and a data files.",
             vec![
-                CommandInput::new(
+                CommandInput::new_required(
                     "db",
                     get_word,
-                    None,
                     Some(database_name_completer_fn(driver.clone(), runtime.clone())),
                 ),
-                CommandInput::new("schema file path", get_word, None, None),
-                CommandInput::new("data file path", get_word, None, None),
+                CommandInput::new_required("schema file path", get_word, None),
+                CommandInput::new_required("data file path", get_word, None),
             ],
             database_export,
         ));
@@ -397,23 +398,23 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
             "create",
             "Create new user.",
             vec![
-                CommandInput::new("name", get_word, None, None),
-                CommandInput::new("password", get_word, Some(get_word), None),
+                CommandInput::new_required("name", get_word,  None),
+                CommandInput::new_hidden("password", get_word, get_word, None),
             ],
             user_create,
         ))
         .add(CommandLeaf::new_with_input(
             "delete",
             "Delete existing user.",
-            CommandInput::new("name", get_word, None, None),
+            CommandInput::new_required("name", get_word, None),
             user_delete,
         ))
         .add(CommandLeaf::new_with_inputs(
             "update-password",
             "Set existing user's password.",
             vec![
-                CommandInput::new("name", get_word, None, None),
-                CommandInput::new("new password", get_word, Some(get_word), None),
+                CommandInput::new_required("name", get_word, None),
+                CommandInput::new_hidden("new password", get_word, get_word, None),
             ],
             user_update_password,
         ));
@@ -422,19 +423,19 @@ fn entry_repl(driver: Arc<TypeDBDriver>, runtime: BackgroundRuntime) -> Repl<Con
         .add(CommandLeaf::new_with_input(
             "read",
             "Open read transaction.",
-            CommandInput::new("db", get_word, None, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
+            CommandInput::new_required("db", get_word, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
             transaction_read,
         ))
         .add(CommandLeaf::new_with_input(
             "write",
             "Open write transaction.",
-            CommandInput::new("db", get_word, None, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
+            CommandInput::new_required("db", get_word, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
             transaction_write,
         ))
         .add(CommandLeaf::new_with_input(
             "schema",
             "Open schema transaction.",
-            CommandInput::new("db", get_word, None, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
+            CommandInput::new_required("db", get_word, Some(database_name_completer_fn(driver.clone(), runtime.clone()))),
             transaction_schema,
         ));
 
@@ -470,14 +471,14 @@ fn transaction_repl(database: &str, transaction_type: TransactionType) -> Repl<C
         .add(CommandLeaf::new_with_input(
             "source",
             "Synchronously execute a file containing a sequence of TypeQL queries with full validation. Queries can be explicitly ended with 'end;' if required. May be a HTTP-hosted file, an absolute path, or a relative path. Relative paths are relative to the invoking script (if there is one) or else a path relative to the current working directory.",
-            CommandInput::new("file", get_word, None, Some(Box::new(file_completer))),
+            CommandInput::new_required("file", get_word, Some(Box::new(file_completer))),
             transaction_source,
         ))
         // default: no token
         .add(CommandLeaf::new_with_input(
             "",
             "Execute query string.",
-            CommandInput::new("query", parse_one_query, None, None),
+            CommandInput::new_required("query", parse_one_query, None),
             transaction_query,
         ));
     repl

--- a/src/main.rs
+++ b/src/main.rs
@@ -469,7 +469,7 @@ fn transaction_repl(database: &str, transaction_type: TransactionType) -> Repl<C
         ))
         .add(CommandLeaf::new_with_input(
             "source",
-            "Synchronously execute a file containing a sequence of TypeQL queries with full validation. Queries can be explicitly ended with 'end;' if required. May be a HTTP-hosted file, an absolute path, or a path relative to the invoking script (if there is one) else a path relative to the current working directory.",
+            "Synchronously execute a file containing a sequence of TypeQL queries with full validation. Queries can be explicitly ended with 'end;' if required. May be a HTTP-hosted file, an absolute path, or a relative path. Relative paths are relative to the invoking script (if there is one) or else a path relative to the current working directory.",
             CommandInput::new("file", get_word, None, Some(Box::new(file_completer))),
             transaction_source,
         ))

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -4,13 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    error::Error,
-    fs::read_to_string,
-    path::PathBuf,
-    process::exit,
-    rc::Rc,
-};
+use std::{error::Error, fs::read_to_string, path::PathBuf, process::exit, rc::Rc};
 
 use futures::stream::StreamExt;
 use sha2::Digest;
@@ -380,25 +374,28 @@ impl FileResource {
     fn read(context: &mut ConsoleContext, string: &str) -> Result<Self, Box<dyn Error + Send>> {
         let file_content = if string.starts_with("http://") || string.starts_with("https://") {
             let url = string.to_owned();
-            let response = ureq::get(&url)
-                .call()
-                .map_err(|e| Box::new(std::io::Error::new(
+            let response = ureq::get(&url).call().map_err(|e| {
+                Box::new(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("Failed to fetch file from {}: {}", url, e)
-                )) as Box<dyn Error + Send>)?;
-            response.into_string()
-                .map_err(|e| Box::new(std::io::Error::new(
+                    format!("Failed to fetch file from {}: {}", url, e),
+                )) as Box<dyn Error + Send>
+            })?;
+            response.into_string().map_err(|e| {
+                Box::new(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("Failed to read file content from {}: {}", url, e)
-                )) as Box<dyn Error + Send>)?
+                    format!("Failed to read file content from {}: {}", url, e),
+                )) as Box<dyn Error + Send>
+            })?
         } else {
             let path = context.convert_path(&string);
             if !path.exists() {
                 return Err(Box::new(ReplError { message: format!("File not found: {}", path.to_string_lossy()) })
                     as Box<dyn Error + Send>);
             } else if path.is_dir() {
-                return Err(Box::new(ReplError { message: format!("Path must be a file: {}", path.to_string_lossy()) })
-                    as Box<dyn Error + Send>);
+                return Err(
+                    Box::new(ReplError { message: format!("Path must be a file: {}", path.to_string_lossy()) })
+                        as Box<dyn Error + Send>,
+                );
             }
             read_to_string(path).map_err(|err| Box::new(err) as Box<dyn Error + Send>)?
         };
@@ -412,7 +409,9 @@ impl FileResource {
             Err(Box::new(ReplError {
                 message: format!(
                     "Expected '{}' to have sha256 '{expected_sha256}', but calculated '{computed_hash_string}',
-                ", &self.file_source),
+                ",
+                    &self.file_source
+                ),
             }) as Box<dyn Error + Send>)
         } else {
             println!("Successfully verified sha256 checksum of {}", &self.file_source);

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -101,13 +101,13 @@ pub(crate) fn database_create_init(context: &mut ConsoleContext, input: &[String
     let schema_uri = &input[1];
     let data_uri = &input[2];
 
-    database_create(context, &[db_name.clone()])?;
-    transaction_schema(context, &[db_name.clone()])?;
-    transaction_source(context, &[schema_uri.clone()])?;
+    database_create(context, &input[0..1])?;
+    transaction_schema(context, &input[0..1])?;
+    transaction_source(context, &input[1..2])?;
     transaction_commit(context, &[])?;
 
-    transaction_write(context, &[db_name.clone()])?;
-    transaction_source(context, &[data_uri.clone()])?;
+    transaction_write(context, &input[0..1])?;
+    transaction_source(context, &input[2..3])?;
     transaction_commit(context, &[])?;
     println!("Successfully created and initialized database with schema and data.");
     Ok(())

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -54,17 +54,17 @@ pub(crate) fn database_create(context: &mut ConsoleContext, input: &[String]) ->
 }
 
 pub(crate) fn database_create_init(context: &mut ConsoleContext, input: &[String]) -> CommandResult {
-    let db_name = &input[0];
-    let schema_uri = &input[1];
-    let data_uri = &input[2];
+    let db_name = &input[0..1];
+    let schema_uri = &input[1..2];
+    let data_uri = &input[2..3];
 
-    database_create(context, &input[0..1])?;
-    transaction_schema(context, &input[0..1])?;
-    transaction_source(context, &input[1..2])?;
+    database_create(context, db_name)?;
+    transaction_schema(context, db_name)?;
+    transaction_source(context, schema_uri)?;
     transaction_commit(context, &[])?;
 
-    transaction_write(context, &input[0..1])?;
-    transaction_source(context, &input[2..3])?;
+    transaction_write(context, db_name)?;
+    transaction_source(context, data_uri)?;
     transaction_commit(context, &[])?;
     println!("Successfully created and initialized database with schema and data.");
     Ok(())

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -403,8 +403,9 @@ impl FileResource {
     }
 
     fn matches_sha256(&self, expected_sha256: &str) -> Result<(), Box<dyn Error + Send>> {
+        let expected_sha256 = expected_sha256.to_lowercase();
         let expected_sha256 = expected_sha256.trim_start_matches("sha256:");
-        let computed_hash_string = format!("{:x}", sha2::Sha256::digest(&self.file_content));
+        let computed_hash_string = format!("{:x}", sha2::Sha256::digest(&self.file_content)).to_lowercase();
         if expected_sha256 != computed_hash_string {
             Err(Box::new(ReplError {
                 message: format!(

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -19,7 +19,7 @@ use rustyline::{
     highlight::Highlighter,
     hint::Hinter,
 };
-use typeql::{common::error::TypeQLError};
+use typeql::common::error::TypeQLError;
 
 use crate::repl::{line_reader::LineReaderHidden, ReplContext};
 
@@ -200,7 +200,9 @@ impl<Context> CommandLeaf<Context> {
         let first_optional_index = args.iter().position(|input| matches!(input.type_, InputType::Optional));
         if let Some(first_index) = first_optional_index {
             if args.iter().skip(first_index + 1).any(|input| !matches!(input.type_, InputType::Optional)) {
-                panic!("Invalid Console configuration: cannot have non-optional arguments following optional arguments");
+                panic!(
+                    "Invalid Console configuration: cannot have non-optional arguments following optional arguments"
+                );
             }
         }
     }
@@ -258,9 +260,7 @@ impl<Context: ReplContext> Command<Context> for CommandLeaf<Context> {
                                     // note: optional args all come at the end, so we just skip
                                     continue;
                                 }
-                                InputType::RequiredHidden(_) => {
-                                    (argument.request_hidden()?, remaining)
-                                }
+                                InputType::RequiredHidden(_) => (argument.request_hidden()?, remaining),
                                 InputType::RequiredVisible => {
                                     return Err(Box::new(ReplError {
                                         message: format!("Missing argument {}: {}", index + 1, argument.usage),
@@ -384,7 +384,7 @@ impl CommandInput {
         match self.type_ {
             InputType::Optional => format!("[optional] {}", self.usage),
             InputType::RequiredVisible => self.usage.to_owned(),
-            InputType::RequiredHidden(_) => format!("{} (enter in hidden input)", self.usage)
+            InputType::RequiredHidden(_) => format!("{} (enter in hidden input)", self.usage),
         }
     }
 }

--- a/src/repl/command.rs
+++ b/src/repl/command.rs
@@ -281,7 +281,7 @@ impl<Context: ReplContext> Command<Context> for CommandLeaf<Context> {
     fn usage_description(&self) -> Box<dyn Iterator<Item = (String, &'static str)> + '_> {
         let mut usage = format!("{}", self.token);
         for arg in &self.arguments {
-            usage = format!("{} <{}>", usage, arg.usage());
+            usage = format!("{} {}", usage, arg.usage());
         }
         Box::new([(usage, self.description)].into_iter())
     }
@@ -382,9 +382,9 @@ impl CommandInput {
 
     fn usage(&self) -> String {
         match self.type_ {
-            InputType::Optional => format!("[optional] {}", self.usage),
-            InputType::RequiredVisible => self.usage.to_owned(),
-            InputType::RequiredHidden(_) => format!("{} (enter in hidden input)", self.usage),
+            InputType::Optional => format!("[{}]", self.usage),
+            InputType::RequiredVisible => format!("<{}>", self.usage),
+            InputType::RequiredHidden(_) => format!("<{} (hidden input)>", self.usage),
         }
     }
 }
@@ -546,7 +546,7 @@ impl<Context: ReplContext> CommandDefinitions for Subcommand<Context> {
                         return true;
                     }
                 }
-                Err(err) => return false,
+                Err(_err) => return false,
             }
         }
     }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -74,7 +74,7 @@ impl<Context: ReplContext + 'static> Repl<Context> {
         const INLINE_HELP_THRESHOLD: usize = 100;
         let widest_usage_under_threshold = usages_descriptions
             .iter()
-            .filter(|(usage, description)| usage.len()+ description.len() < INLINE_HELP_THRESHOLD)
+            .filter(|(usage, description)| usage.len() + description.len() < INLINE_HELP_THRESHOLD)
             .map(|(usage, _)| usage.len())
             .max()
             .unwrap_or(0);


### PR DESCRIPTION
## Usage and product changes

We introduce a new command `database create-init`, which 

1) create the new database
2) loads a provided schema file (from URL, or from local file)
3) loads a provided data file (from URL or from local file)

Command format:
```
database create-init <db> <schema file> <data file> <[optional] schema file sha256 (hex or sha256:hex)> <[optional] data file sha256 (hex or sha256:hex)>
```

Usage example to load bookstore example from `typedb-examples`:
```
>> database create-init bookstore https://github.com/typedb/typedb-examples/releases/download/3.5.0/bookstore-schema.tql https://github.com/typedb/typedb-examples/releases/download/3.5.0/bookstore-data.tql
```

You can also optionally provide sha256 checksums to verify your files are correct (these come from the Github releases page):
```
>> database create-init bookstore https://github.com/typedb/typedb-examples/releases/download/3.5.0/bookstore-schema.tql https://github.com/typedb/typedb-examples/releases/download/3.5.0/bookstore-data.tql sha256:b2de488d9f64ccdfdba016029c7932be69ec5d35d18977c85bb12ad4cc97e95f sha256:828806afe1ce939d0ee87d6ae89598f5d7f967155c7757263b151673480bcad1
```

We've also upgraded the `source` command in a transaction to allow reading from a remote URL, not just local files:
```
bookstore::write >> source https://github.com/typedb/typedb-examples/releases/download/3.5.0/bookstore-data.tql 
```

This can also optionally take a sha256 (the `sha256:` prefix optional):
```
bookstore::write >> source https://github.com/typedb/typedb-examples/releases/download/3.5.0/bookstore-data.tql 828806afe1ce939d0ee87d6ae89598f5d7f967155c7757263b151673480bcad1
```

These commands can also receive local in relative or absolute path formats.

## Implementation

Chain together database creation, and schema+data file sourcing. 

Extend the existing `source` behaviour to allow retriving the file over the network from a remote URL.

Refactor the help menu to make it handle the long content more effectively.